### PR TITLE
Workaround for the log4j MDC bug in Jboss AS 7.1.1

### DIFF
--- a/src/main/assembly/module.xml
+++ b/src/main/assembly/module.xml
@@ -8,5 +8,6 @@
 
     <dependencies>
         <module name="org.apache.log4j" />
+        <module name="org.slf4j" />
     </dependencies>
 </module>

--- a/src/main/java/biz/paluch/logging/gelf/jboss7/JBoss7JulLogEvent.java
+++ b/src/main/java/biz/paluch/logging/gelf/jboss7/JBoss7JulLogEvent.java
@@ -39,6 +39,7 @@ public class JBoss7JulLogEvent extends JulLogEvent {
         if (value != null) {
             return value.toString();
         }
-        return null;
+        String slf4jValue = org.slf4j.MDC.get(mdcName);
+        return slf4jValue;
     }
 }


### PR DESCRIPTION
Workaround for the log4j MDC not backed by JBoss Logging MDC in JBoss AS 7.1.1 (not any more present in upstream version but JBoss AS 7.1.1 is last community release of JBoss AS 7).

The workaround simply first checks the log4j MDC and if no value is present, checks slf4j (which is correctly backed by JBoss Logging MDC) for the MDC value.

This should allow usage of the log4j, slf4j and JBoss Logging MDC with the Gelf handler.
