### PR TITLE
Logback appender should use formatted message

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/logback/LogbackLogEvent.java
+++ b/src/main/java/biz/paluch/logging/gelf/logback/LogbackLogEvent.java
@@ -30,7 +30,7 @@ class LogbackLogEvent implements LogEvent {
 
     @Override
     public String getMessage() {
-        return loggingEvent.getMessage();
+        return loggingEvent.getFormattedMessage();
     }
 
     @Override


### PR DESCRIPTION
Logback appender should use the formatted message instead of the raw one.

E.g.: logger.info("This is {}", "Jack") should send "This is Jack" instead of "This is {}" .
