### PR TITLE
JBoss 7 Logging Modification for Async support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <jedis-commons-pool2.version>2.2</jedis-commons-pool2.version>
         <slf4j-api.version>1.7.5</slf4j-api.version>
         <logback-classic.version>1.0.13</logback-classic.version>
+        <org.jboss.logmanager.version>1.5.2.Final</org.jboss.logmanager.version>
 
         <site-plugin.version>3.3</site-plugin.version>
         <maven-javadoc-plugin.version>2.7</maven-javadoc-plugin.version>
@@ -289,6 +290,13 @@
             <version>${jedis-commons-pool2.version}</version>
         </dependency>
 
+		<!--JBoss Logging -->
+		<dependency>
+			<groupId>org.jboss.logmanager</groupId>
+			<artifactId>jboss-logmanager</artifactId>
+			<version>${org.jboss.logmanager.version}</version>
+			<scope>provided</scope>
+		</dependency>
     </dependencies>
 
     <reporting>

--- a/src/main/assembly/module.xml
+++ b/src/main/assembly/module.xml
@@ -12,5 +12,6 @@
         <module name="org.apache.log4j" />
         <module name="org.slf4j" />
         <module name="javax.api" />
+        <module name="org.jboss.logmanager" />
     </dependencies>
 </module>

--- a/src/main/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandler.java
+++ b/src/main/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandler.java
@@ -1,5 +1,6 @@
 package biz.paluch.logging.gelf.jboss7;
 
+
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.LoggerName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.NDC;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.Severity;
@@ -8,6 +9,10 @@ import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.SourceMethod
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.SourceSimpleClassName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.ThreadName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.Time;
+
+import java.util.logging.LogRecord;
+import org.jboss.logmanager.ExtLogRecord;
+
 import biz.paluch.logging.gelf.DynamicMdcMessageField;
 import biz.paluch.logging.gelf.GelfMessageAssembler;
 import biz.paluch.logging.gelf.LogMessageField;
@@ -15,8 +20,6 @@ import biz.paluch.logging.gelf.MdcGelfMessageAssembler;
 import biz.paluch.logging.gelf.MdcMessageField;
 import biz.paluch.logging.gelf.StaticMessageField;
 import biz.paluch.logging.gelf.intern.GelfMessage;
-
-import java.util.logging.LogRecord;
 
 /**
  * Logging-Handler for GELF (Graylog Extended Logging Format). This Java-Util-Logging Handler creates GELF Messages and posts
@@ -77,12 +80,17 @@ public class JBoss7GelfLogHandler extends biz.paluch.logging.gelf.jul.GelfLogHan
     }
 
     @Override
+    public void publish(LogRecord record) {
+        super.publish(ExtLogRecord.wrap(record));
+    }
+
+    @Override
     protected GelfMessageAssembler createGelfMessageAssembler() {
         return new MdcGelfMessageAssembler();
     }
 
     protected GelfMessage createGelfMessage(final LogRecord record) {
-        return getGelfMessageAssembler().createGelfMessage(new JBoss7JulLogEvent(record));
+        return getGelfMessageAssembler().createGelfMessage(new JBoss7JulLogEvent((ExtLogRecord)record));
     }
 
     public void setAdditionalFields(String fieldSpec) {

--- a/src/test/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandlerDynamicMdcTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandlerDynamicMdcTest.java
@@ -4,12 +4,10 @@ import static biz.paluch.logging.gelf.jboss7.JBoss7LogTestUtil.getJBoss7GelfLogH
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
-import org.apache.log4j.MDC;
+import org.jboss.logmanager.MDC;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,19 +33,8 @@ public class JBoss7GelfLogHandlerDynamicMdcTest
     @Before
     public void before() throws Exception {
         GelfTestSender.getMessages().clear();
-
-        JBoss7GelfLogHandler handler = getLogHandler();
         LogManager.getLogManager().reset();
-
-        if (MDC.getContext() != null && MDC.getContext().keySet() != null) {
-
-            Set<String> keys = new HashSet<String>(MDC.getContext().keySet());
-
-            for (String key : keys) {
-                MDC.remove(key);
-            }
-        }
-        org.slf4j.MDC.clear();
+        MDC.clear();
     }
 
     @Test
@@ -117,9 +104,9 @@ public class JBoss7GelfLogHandlerDynamicMdcTest
         Logger logger = Logger.getLogger(getClass().getName());
         logger.addHandler(handler);
 
-        org.apache.log4j.MDC.put(MDC_MY_MDC, VALUE_1);
-        org.slf4j.MDC.put(MY_MDC_WITH_SUFFIX1, VALUE_2);
-        org.slf4j.MDC.put(MY_MDC_WITH_SUFFIX2, VALUE_3);
+        MDC.put(MDC_MY_MDC, VALUE_1);
+        MDC.put(MY_MDC_WITH_SUFFIX1, VALUE_2);
+        MDC.put(MY_MDC_WITH_SUFFIX2, VALUE_3);
 
         logger.info(LOG_MESSAGE);
         assertEquals(1, GelfTestSender.getMessages().size());

--- a/src/test/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandlerTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandlerTest.java
@@ -4,17 +4,20 @@ import static biz.paluch.logging.gelf.jboss7.JBoss7LogTestUtil.getJBoss7GelfLogH
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import biz.paluch.logging.gelf.GelfTestSender;
-import biz.paluch.logging.gelf.intern.GelfMessage;
-import org.apache.log4j.MDC;
-import org.apache.log4j.NDC;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.MDC;
+import org.jboss.logmanager.NDC;
+import org.junit.Before;
+import org.junit.Test;
+
+import biz.paluch.logging.gelf.GelfTestSender;
+import biz.paluch.logging.gelf.intern.GelfMessage;
 
 /**
  * @author <a href="mailto:mpaluch@paluch.biz">Mark Paluch</a>
@@ -28,9 +31,7 @@ public class JBoss7GelfLogHandlerTest {
     @Before
     public void before() throws Exception {
         GelfTestSender.getMessages().clear();
-
         LogManager.getLogManager().reset();
-
         MDC.remove("mdcField1");
     }
 
@@ -143,7 +144,7 @@ public class JBoss7GelfLogHandlerTest {
 
         handler.setGraylogHost(null);
         handler.setGraylogPort(0);
-        handler.createGelfMessage(new LogRecord(Level.ALL, LOG_MESSAGE));
+        handler.createGelfMessage(ExtLogRecord.wrap(new LogRecord(Level.ALL, LOG_MESSAGE)));
 
     }
 }


### PR DESCRIPTION
Modified the JBoss 7 Logging part: Using the JBoss-specific ExtLogRecord instead of JUL LogRecord.
Reason: The MDC/NDC implementation doesn't work for async logging (e.g. JBoss Built-In AsyncAppender) because the thread-context of MDC/NDC is lost in worker thread(s). 
JBoss ExtLogRecord has built-in support for getting MDC/NDC parts AND has a "copyAll" - method which copies thread-context specific things (like MDC) to the LogRecord. This method is also called on JBoss Built-in Async Appender.

With my modifications all MDC/NDC fields are now available in the Gelf-Message when using the AsyncAppender
