### PR TITLE
Sender specific configurations on sender factory

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/intern/GelfSenderConfiguration.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/GelfSenderConfiguration.java
@@ -1,5 +1,7 @@
 package biz.paluch.logging.gelf.intern;
 
+import java.util.Map;
+
 /**
  * Configuration for a Gelf Sender.
  */
@@ -22,4 +24,9 @@ public interface GelfSenderConfiguration {
      * @return the ErrorReporter to report any errors
      */
     ErrorReporter getErrorReporter();
+    
+    /**
+     * Returns some sender specific configurations
+     */
+    Map<String,Object> getSpecificConfigurations(); 
 }

--- a/src/main/java/biz/paluch/logging/gelf/intern/GelfSenderFactory.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/GelfSenderFactory.java
@@ -1,15 +1,16 @@
 package biz.paluch.logging.gelf.intern;
 
-import biz.paluch.logging.gelf.intern.sender.DefaultGelfSenderProvider;
-import biz.paluch.logging.gelf.intern.sender.RedisGelfSenderProvider;
-
 import java.io.IOException;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
+
+import biz.paluch.logging.gelf.intern.sender.DefaultGelfSenderProvider;
+import biz.paluch.logging.gelf.intern.sender.RedisGelfSenderProvider;
 
 /**
  * @author <a href="mailto:mpaluch@paluch.biz">Mark Paluch</a>
@@ -23,7 +24,7 @@ public final class GelfSenderFactory {
      * @param hostAndPortProvider
      * @return GelfSender.
      */
-    public static GelfSender createSender(final HostAndPortProvider hostAndPortProvider, final ErrorReporter errorReporter) {
+    public static GelfSender createSender(final HostAndPortProvider hostAndPortProvider, final ErrorReporter errorReporter, final Map<String,Object> senderSpecificConfigurations) {
         GelfSenderConfiguration senderConfiguration = new GelfSenderConfiguration() {
 
             @Override
@@ -40,6 +41,13 @@ public final class GelfSenderFactory {
             public ErrorReporter getErrorReporter() {
                 return errorReporter;
             }
+
+            @Override
+            public Map<String, Object> getSpecificConfigurations() {
+                return senderSpecificConfigurations;
+            }
+            
+            
         };
 
         return createSender(senderConfiguration);

--- a/src/main/java/biz/paluch/logging/gelf/jul/GelfLogHandler.java
+++ b/src/main/java/biz/paluch/logging/gelf/jul/GelfLogHandler.java
@@ -17,6 +17,8 @@ import biz.paluch.logging.gelf.intern.GelfMessage;
 import biz.paluch.logging.gelf.intern.GelfSender;
 import biz.paluch.logging.gelf.intern.GelfSenderFactory;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.logging.ErrorManager;
 import java.util.logging.Filter;
 import java.util.logging.Handler;
@@ -104,7 +106,7 @@ public class GelfLogHandler extends Handler implements ErrorReporter {
         }
         try {
             if (null == gelfSender) {
-                gelfSender = GelfSenderFactory.createSender(gelfMessageAssembler, this);
+                gelfSender = createGelfSender();
             }
         } catch (Exception e) {
             reportError("Could not send GELF message: " + e.getMessage(), e, ErrorManager.OPEN_FAILURE);
@@ -124,6 +126,10 @@ public class GelfLogHandler extends Handler implements ErrorReporter {
         } catch (Exception e) {
             reportError("Could not send GELF message: " + e.getMessage(), e, ErrorManager.FORMAT_FAILURE);
         }
+    }
+    
+    protected GelfSender createGelfSender() {
+        return GelfSenderFactory.createSender(gelfMessageAssembler, this, Collections.EMPTY_MAP);
     }
 
     @Override

--- a/src/main/java/biz/paluch/logging/gelf/log4j/GelfLogAppender.java
+++ b/src/main/java/biz/paluch/logging/gelf/log4j/GelfLogAppender.java
@@ -8,6 +8,11 @@ import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.SourceMethod
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.SourceSimpleClassName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.ThreadName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.Time;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import biz.paluch.logging.gelf.DynamicMdcMessageField;
 import biz.paluch.logging.gelf.LogMessageField;
 import biz.paluch.logging.gelf.MdcGelfMessageAssembler;
@@ -72,6 +77,8 @@ public class GelfLogAppender extends AppenderSkeleton implements ErrorReporter {
 
     protected GelfSender gelfSender;
     protected MdcGelfMessageAssembler gelfMessageAssembler;
+    protected Map<String,Object> senderSpecificProperties = new HashMap<String,Object>();
+
 
     public GelfLogAppender() {
         gelfMessageAssembler = new MdcGelfMessageAssembler();
@@ -87,7 +94,7 @@ public class GelfLogAppender extends AppenderSkeleton implements ErrorReporter {
 
         try {
             if (null == gelfSender) {
-                gelfSender = GelfSenderFactory.createSender(gelfMessageAssembler, this);
+                gelfSender = createGelfSender();
             }
 
             GelfMessage message = createGelfMessage(event);
@@ -102,6 +109,10 @@ public class GelfLogAppender extends AppenderSkeleton implements ErrorReporter {
         } catch (Exception e) {
             reportError("Could not send GELF message: " + e.getMessage(), e);
         }
+    }
+
+    protected GelfSender createGelfSender() {
+        return GelfSenderFactory.createSender(gelfMessageAssembler, this, Collections.EMPTY_MAP);
     }
 
     public void reportError(String message, Exception exception) {
@@ -248,4 +259,6 @@ public class GelfLogAppender extends AppenderSkeleton implements ErrorReporter {
     public void setIncludeFullMdc(boolean includeFullMdc) {
         gelfMessageAssembler.setIncludeFullMdc(includeFullMdc);
     }
+
+    
 }

--- a/src/main/java/biz/paluch/logging/gelf/log4j2/GelfLogAppender.java
+++ b/src/main/java/biz/paluch/logging/gelf/log4j2/GelfLogAppender.java
@@ -8,6 +8,11 @@ import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.SourceMethod
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.SourceSimpleClassName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.ThreadName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.Time;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import biz.paluch.logging.gelf.DynamicMdcMessageField;
 import biz.paluch.logging.gelf.LogMessageField;
 import biz.paluch.logging.gelf.MdcGelfMessageAssembler;
@@ -168,6 +173,7 @@ import org.apache.logging.log4j.util.Strings;
 public class GelfLogAppender extends AbstractAppender implements ErrorReporter {
     private static final Logger LOGGER = StatusLogger.getLogger();
 
+    protected Map<String,Object> senderSpecificProperties = new HashMap<String,Object>();
     protected GelfSender gelfSender;
     private MdcGelfMessageAssembler gelfMessageAssembler;
 
@@ -341,8 +347,15 @@ public class GelfLogAppender extends AbstractAppender implements ErrorReporter {
     @Override
     public void start() {
         if (null == gelfSender) {
-            gelfSender = GelfSenderFactory.createSender(gelfMessageAssembler, this);
+            gelfSender = createGelfSender();
         }
         super.start();
     }
+
+    protected GelfSender createGelfSender() {
+        return GelfSenderFactory.createSender(gelfMessageAssembler, this, Collections.EMPTY_MAP);
+    }
+
+    
+    
 }

--- a/src/main/java/biz/paluch/logging/gelf/logback/GelfLogbackAppender.java
+++ b/src/main/java/biz/paluch/logging/gelf/logback/GelfLogbackAppender.java
@@ -8,6 +8,11 @@ import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.SourceMethod
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.SourceSimpleClassName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.ThreadName;
 import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.Time;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import biz.paluch.logging.gelf.DynamicMdcMessageField;
 import biz.paluch.logging.gelf.LogMessageField;
 import biz.paluch.logging.gelf.MdcGelfMessageAssembler;
@@ -73,6 +78,7 @@ public class GelfLogbackAppender extends AppenderBase<ILoggingEvent> implements 
 
     protected GelfSender gelfSender;
     protected MdcGelfMessageAssembler gelfMessageAssembler;
+    protected Map<String,Object> senderSpecificProperties = new HashMap<String,Object>();
 
     public GelfLogbackAppender() {
         gelfMessageAssembler = new MdcGelfMessageAssembler();
@@ -88,7 +94,7 @@ public class GelfLogbackAppender extends AppenderBase<ILoggingEvent> implements 
 
         try {
             if (null == gelfSender) {
-                gelfSender = GelfSenderFactory.createSender(gelfMessageAssembler, this);
+                gelfSender = createGelfSender();
             }
 
             GelfMessage message = createGelfMessage(event);
@@ -104,6 +110,11 @@ public class GelfLogbackAppender extends AppenderBase<ILoggingEvent> implements 
             reportError("Could not send GELF message: " + e.getMessage(), e);
         }
     }
+    
+    protected GelfSender createGelfSender() {
+        return GelfSenderFactory.createSender(gelfMessageAssembler, this, Collections.EMPTY_MAP);
+    }
+
 
     public void reportError(String message, Exception exception) {
         addError(message, exception);
@@ -236,4 +247,8 @@ public class GelfLogbackAppender extends AppenderBase<ILoggingEvent> implements 
     public void setIncludeFullMdc(boolean includeFullMdc) {
         gelfMessageAssembler.setIncludeFullMdc(includeFullMdc);
     }
+
+   
+    
+    
 }

--- a/src/main/java/biz/paluch/logging/gelf/standalone/DefaultGelfSenderConfiguration.java
+++ b/src/main/java/biz/paluch/logging/gelf/standalone/DefaultGelfSenderConfiguration.java
@@ -1,5 +1,8 @@
 package biz.paluch.logging.gelf.standalone;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import biz.paluch.logging.gelf.intern.ErrorReporter;
 import biz.paluch.logging.gelf.intern.GelfSenderConfiguration;
 
@@ -14,6 +17,7 @@ public class DefaultGelfSenderConfiguration implements GelfSenderConfiguration {
     private ErrorReporter errorReporter;
     private String host;
     private int port;
+    protected Map<String,Object> specificConfigurations = new HashMap<String,Object>();
 
     public DefaultGelfSenderConfiguration() {
         errorReporter = new Slf4jErrorReporter();
@@ -49,4 +53,17 @@ public class DefaultGelfSenderConfiguration implements GelfSenderConfiguration {
     public void setPort(int port) {
         this.port = port;
     }
+
+    @Override
+    public Map<String, Object> getSpecificConfigurations() {
+        return specificConfigurations;
+    }
+
+    public void setSpecificConfigurations(Map<String, Object> specificConfigurations) {
+        this.specificConfigurations = specificConfigurations;
+    }
+
+   
+    
+    
 }

--- a/src/test/java/biz/paluch/logging/gelf/intern/GelfSenderFactoryTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/GelfSenderFactoryTest.java
@@ -17,6 +17,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.io.IOException;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GelfSenderFactoryTest {
@@ -56,7 +58,7 @@ public class GelfSenderFactoryTest {
         mockSupports();
         when(senderProvider.create(any(GelfSenderConfiguration.class))).thenReturn(sender);
 
-        GelfSender result = sut.createSender(assembler, errorReporter);
+        GelfSender result = sut.createSender(assembler, errorReporter, Collections.EMPTY_MAP);
 
         assertSame(sender, result);
     }
@@ -64,7 +66,7 @@ public class GelfSenderFactoryTest {
     @Test
     public void testCreateSenderFail() throws Exception {
 
-        GelfSender result = sut.createSender(assembler, errorReporter);
+        GelfSender result = sut.createSender(assembler, errorReporter,Collections.EMPTY_MAP);
         assertNull(result);
     }
 
@@ -74,7 +76,7 @@ public class GelfSenderFactoryTest {
         mockSupports();
         when(senderProvider.create(any(GelfSenderConfiguration.class))).thenThrow(new UnknownHostException());
 
-        GelfSender result = sut.createSender(assembler, errorReporter);
+        GelfSender result = sut.createSender(assembler, errorReporter,Collections.EMPTY_MAP);
         assertNull(result);
 
         verify(errorReporter).reportError(anyString(), any(UnknownHostException.class));
@@ -87,7 +89,7 @@ public class GelfSenderFactoryTest {
         mockSupports();
         when(senderProvider.create(any(GelfSenderConfiguration.class))).thenThrow(new SocketException());
 
-        GelfSender result = sut.createSender(assembler, errorReporter);
+        GelfSender result = sut.createSender(assembler, errorReporter,Collections.EMPTY_MAP);
         assertNull(result);
 
         verify(errorReporter).reportError(anyString(), any(SocketException.class));
@@ -100,7 +102,7 @@ public class GelfSenderFactoryTest {
         mockSupports();
         when(senderProvider.create(any(GelfSenderConfiguration.class))).thenThrow(new IOException());
 
-        GelfSender result = sut.createSender(assembler, errorReporter);
+        GelfSender result = sut.createSender(assembler, errorReporter,Collections.EMPTY_MAP);
         assertNull(result);
 
         verify(errorReporter).reportError(anyString(), any(IOException.class));
@@ -113,7 +115,7 @@ public class GelfSenderFactoryTest {
         mockSupports();
         when(senderProvider.create(any(GelfSenderConfiguration.class))).thenThrow(new NullPointerException());
 
-        sut.createSender(assembler, errorReporter);
+        sut.createSender(assembler, errorReporter,new HashMap<String, Object>());
 
     }
 


### PR DESCRIPTION
Added the possibility for sender specific (sender) configurations on sender factory .
Cause: Sometimes very (company) specific sender specifications are needed, which cannot be configured system-wide. Now its possible to inject them, by overriding or wrapping the original Logging-IMplementations.
