### PR TITLE
Added Log4j-1.x gelf layout

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/log4j/GelfLayout.java
+++ b/src/main/java/biz/paluch/logging/gelf/log4j/GelfLayout.java
@@ -1,0 +1,70 @@
+package biz.paluch.logging.gelf.log4j;
+
+import static biz.paluch.logging.gelf.LogMessageField.NamedLogField.*;
+
+import org.apache.log4j.Layout;
+import org.apache.log4j.spi.LoggingEvent;
+
+import biz.paluch.logging.gelf.LogMessageField;
+import biz.paluch.logging.gelf.MdcGelfMessageAssembler;
+import biz.paluch.logging.gelf.intern.GelfMessage;
+
+public class GelfLayout extends Layout {
+
+	private final MdcGelfMessageAssembler gelfMessageAssembler;
+
+	public GelfLayout() {
+		super();
+		gelfMessageAssembler = new MdcGelfMessageAssembler();
+		gelfMessageAssembler.addFields(LogMessageField.getDefaultMapping(Time, Severity, ThreadName, SourceClassName, SourceMethodName,
+				SourceLineNumber, SourceSimpleClassName, LoggerName, NDC));
+	}
+
+	@Override
+	public String format(LoggingEvent loggingEvent) {
+		GelfMessage gelfMessage = gelfMessageAssembler.createGelfMessage(new Log4jLogEvent(loggingEvent));
+		return gelfMessage.toJson("") + System.lineSeparator();
+	}
+
+	@Override
+	public boolean ignoresThrowable() {
+		return false;
+	}
+
+	@Override
+	public void activateOptions() {
+
+	}
+
+	public void setMdcProfiling(boolean mdcProfiling) {
+		gelfMessageAssembler.setMdcProfiling(mdcProfiling);
+	}
+
+	public boolean isMdcProfiling() {
+		return gelfMessageAssembler.isMdcProfiling();
+	}
+
+	public void setIncludeFullMdc(boolean includeFullMdc) {
+		gelfMessageAssembler.setIncludeFullMdc(includeFullMdc);
+	}
+
+	public boolean isIncludeFullMdc() {
+		return gelfMessageAssembler.isIncludeFullMdc();
+	}
+
+	public void setExtractStackTrace(boolean extractStacktrace) {
+		gelfMessageAssembler.setExtractStackTrace(extractStacktrace);
+	}
+
+	public boolean isExtractStackTrace() {
+		return gelfMessageAssembler.isExtractStackTrace();
+	}
+
+	public void setFilterStackTrace(boolean filterStackTrace) {
+		gelfMessageAssembler.setFilterStackTrace(filterStackTrace);
+	}
+
+	public boolean isFilterStackTrace() {
+		return gelfMessageAssembler.isFilterStackTrace();
+	}
+}

--- a/src/main/java/biz/paluch/logging/gelf/log4j/GelfLayout.java
+++ b/src/main/java/biz/paluch/logging/gelf/log4j/GelfLayout.java
@@ -9,6 +9,16 @@ import biz.paluch.logging.gelf.LogMessageField;
 import biz.paluch.logging.gelf.MdcGelfMessageAssembler;
 import biz.paluch.logging.gelf.intern.GelfMessage;
 
+/**
+ * Log layout format for GELF (Graylog Extended Logging Format). Following parameters are supported:
+ * <ul>
+ * <li>extractStackTrace (Optional): Post Stack-Trace to StackTrace field, default false</li>
+ * <li>filterStackTrace (Optional): Perform Stack-Trace filtering (true/false), default false</li>
+ * <li>includeFullMdc (Optional): Include all fields from the MDC, default false</li>
+ * <li>mdcProfiling (Optional): Perform Profiling (Call-Duration) based on MDC Data. See <a href="#mdcProfiling">MDC Profiling</a>, default
+ * false</li>
+ * </ul>
+ */
 public class GelfLayout extends Layout {
 
 	private final MdcGelfMessageAssembler gelfMessageAssembler;
@@ -23,7 +33,7 @@ public class GelfLayout extends Layout {
 	@Override
 	public String format(LoggingEvent loggingEvent) {
 		GelfMessage gelfMessage = gelfMessageAssembler.createGelfMessage(new Log4jLogEvent(loggingEvent));
-		return gelfMessage.toJson("") + System.lineSeparator();
+		return gelfMessage.toJson("") + Layout.LINE_SEP;
 	}
 
 	@Override

--- a/src/test/java/biz/paluch/logging/gelf/log4j/GelfLayoutTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/log4j/GelfLayoutTest.java
@@ -1,0 +1,43 @@
+package biz.paluch.logging.gelf.log4j;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.xml.DOMConfigurator;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GelfLayoutTest {
+
+	private static Logger logger;
+
+	@BeforeClass
+	public static void beforeClass() {
+		DOMConfigurator.configure(GelfLayoutTest.class.getResource("/log4j-gelf-layout.xml"));
+		logger = Logger.getLogger(GelfLayoutTest.class);
+	}
+
+	@Before
+	public void before() {
+		TestAppender.clearLoggedLines();
+	}
+
+	@Test
+	public void test() {
+		logger.info("test1");
+		logger.info("test2");
+		logger.info("test3");
+		String[] loggedLines = TestAppender.getLoggedLines();
+		assertThat(loggedLines.length).isEqualTo(3);
+		assertThat(parseToJSONObject(loggedLines[0]).get("full_message")).isEqualTo("test1");
+		assertThat(parseToJSONObject(loggedLines[1]).get("full_message")).isEqualTo("test2");
+		assertThat(parseToJSONObject(loggedLines[2]).get("full_message")).isEqualTo("test3");
+	}
+
+	private JSONObject parseToJSONObject(String value) {
+		return (JSONObject) JSONValue.parse(value);
+	}
+}

--- a/src/test/java/biz/paluch/logging/gelf/log4j/TestAppender.java
+++ b/src/test/java/biz/paluch/logging/gelf/log4j/TestAppender.java
@@ -22,7 +22,7 @@ public class TestAppender extends WriterAppender {
 
 	public static String[] getLoggedLines() {
 		String loggedLines = TestAppender.baos.toString();
-		return loggedLines.split(System.lineSeparator());
+		return loggedLines.split(Layout.LINE_SEP);
 	}
 
 	public static void clearLoggedLines() {

--- a/src/test/java/biz/paluch/logging/gelf/log4j/TestAppender.java
+++ b/src/test/java/biz/paluch/logging/gelf/log4j/TestAppender.java
@@ -1,0 +1,31 @@
+package biz.paluch.logging.gelf.log4j;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+
+import org.apache.log4j.Layout;
+import org.apache.log4j.WriterAppender;
+
+public class TestAppender extends WriterAppender {
+
+	private static final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+	private static final OutputStreamWriter writer = new OutputStreamWriter(baos);
+
+	public TestAppender() {
+		setWriter(writer);
+	}
+
+	public TestAppender(Layout layout) {
+		setWriter(writer);
+		setLayout(layout);
+	}
+
+	public static String[] getLoggedLines() {
+		String loggedLines = TestAppender.baos.toString();
+		return loggedLines.split(System.lineSeparator());
+	}
+
+	public static void clearLoggedLines() {
+		baos.reset();
+	}
+}

--- a/src/test/resources/log4j-gelf-layout.xml
+++ b/src/test/resources/log4j-gelf-layout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+    <appender name="sysout" class="org.apache.log4j.ConsoleAppender">
+        <layout class="biz.paluch.logging.gelf.log4j.GelfLayout"/>
+    </appender>
+
+    <appender name="test" class="biz.paluch.logging.gelf.log4j.TestAppender">
+        <layout class="biz.paluch.logging.gelf.log4j.GelfLayout"/>
+    </appender>
+
+    <root>
+        <priority value="DEBUG"/>
+        <appender-ref ref="sysout"/>
+        <appender-ref ref="test"/>
+    </root>
+
+</log4j:configuration>


### PR DESCRIPTION
We need an mechanism for creating GELF logfiles with Log4j-1.x. Maybe you want to extract the layout part of biz.paluch.logging.gelf.log4j.GelfLogAppender and migrate it to the newly created biz.paluch.logging.gelf.log4j.GelfLayout. Or you tell me to do that ;-)

Best regards
Kai