### PR TITLE
Queue LogRecords when currently publishing.

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandler.java
+++ b/src/main/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandler.java
@@ -80,7 +80,7 @@ public class JBoss7GelfLogHandler extends biz.paluch.logging.gelf.jul.GelfLogHan
     }
 
     @Override
-    public void publish(LogRecord record) {
+    public synchronized void publish(LogRecord record) {
         super.publish(ExtLogRecord.wrap(record));
     }
 

--- a/src/main/java/biz/paluch/logging/gelf/jul/GelfLogHandler.java
+++ b/src/main/java/biz/paluch/logging/gelf/jul/GelfLogHandler.java
@@ -103,7 +103,7 @@ public class GelfLogHandler extends Handler implements ErrorReporter {
     }
 
     @Override
-    public void publish(final LogRecord record) {
+    public synchronized void publish(final LogRecord record) {
         if (!isLoggable(record)) {
             return;
         }

--- a/src/main/java/biz/paluch/logging/gelf/wildfly/WildFlyGelfLogHandler.java
+++ b/src/main/java/biz/paluch/logging/gelf/wildfly/WildFlyGelfLogHandler.java
@@ -74,7 +74,7 @@ public class WildFlyGelfLogHandler extends GelfLogHandler {
     }
 
     @Override
-    public void publish(LogRecord record) {
+    public synchronized void publish(LogRecord record) {
         super.publish(ExtLogRecord.wrap(record));
     }
 


### PR DESCRIPTION
This resolves a problem (on JBoss 7.1.1) with dropped LogRecords when publishing from different threads. While publishing was true, additional calls to publish would have their LogRecords silently dropped.

This is probably a very naive approach, but it appears to work for us (so far).