### PR TITLE
Added GelfHTTPSender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <logback-classic.version>1.1.3</logback-classic.version>
         <org.jboss.logmanager.version>1.5.2.Final</org.jboss.logmanager.version>
         <arquillian.version>1.1.5.Final</arquillian.version>
+        <http-components.version>4.5.1</http-components.version>
 
         <site-plugin.version>3.4</site-plugin.version>
         <maven-javadoc-plugin.version>2.7</maven-javadoc-plugin.version>
@@ -286,6 +287,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- HTTP Logging -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${http-components.version}</version>
+        </dependency>
+
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
@@ -359,6 +368,7 @@
             <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <groupId>biz.paluch.logging</groupId>
-    <version>1.8.1</version>
+    <version>1.8.2-SNAPSHOT</version>
     <artifactId>logstash-gelf</artifactId>
 
     <name>logstash logging connectors</name>
@@ -20,7 +20,7 @@
         <connection>scm:git://github.com/mp911de/logstash-gelf.git</connection>
         <developerConnection>scm:git:git@github.com:mp911de/logstash-gelf.git</developerConnection>
         <url>http://github.com/mp911de/logstash-gelf/</url>
-        <tag>logstash-gelf-1.8.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/DefaultGelfSenderProvider.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/DefaultGelfSenderProvider.java
@@ -3,6 +3,7 @@ package biz.paluch.logging.gelf.intern.sender;
 import biz.paluch.logging.gelf.intern.GelfSender;
 import biz.paluch.logging.gelf.intern.GelfSenderConfiguration;
 import biz.paluch.logging.gelf.intern.GelfSenderProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.io.IOException;
 import java.net.URI;
@@ -10,9 +11,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * 
  * (c) https://github.com/Batigoal/logstash-gelf.git
- * 
  */
 public class DefaultGelfSenderProvider implements GelfSenderProvider {
 
@@ -52,6 +51,9 @@ public class DefaultGelfSenderProvider implements GelfSenderProvider {
             URI uri = URI.create(graylogHost);
             String udpGraylogHost = UriParser.getHost(uri);
             return new GelfUDPSender(udpGraylogHost, port, configuration.getErrorReporter());
+        } else if (graylogHost.startsWith("http")) {
+            return new GelfHTTPSender(graylogHost, port, configuration.getErrorReporter(), HttpClientBuilder.create());
+
         } else {
             return new GelfUDPSender(graylogHost, port, configuration.getErrorReporter());
         }

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/DefaultGelfSenderProvider.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/DefaultGelfSenderProvider.java
@@ -3,12 +3,14 @@ package biz.paluch.logging.gelf.intern.sender;
 import biz.paluch.logging.gelf.intern.GelfSender;
 import biz.paluch.logging.gelf.intern.GelfSenderConfiguration;
 import biz.paluch.logging.gelf.intern.GelfSenderProvider;
-import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static biz.paluch.logging.gelf.GelfUtil.addDefaultPortIfMissing;
 
 /**
  * (c) https://github.com/Batigoal/logstash-gelf.git
@@ -17,13 +19,11 @@ public class DefaultGelfSenderProvider implements GelfSenderProvider {
 
     public static final int DEFAULT_PORT = 12201;
 
-    @Override
-    public boolean supports(String host) {
+    @Override public boolean supports(String host) {
         return host != null;
     }
 
-    @Override
-    public GelfSender create(GelfSenderConfiguration configuration) throws IOException {
+    @Override public GelfSender create(GelfSenderConfiguration configuration) throws IOException {
         String graylogHost = configuration.getHost();
 
         int port = configuration.getPort();
@@ -38,8 +38,7 @@ public class DefaultGelfSenderProvider implements GelfSenderProvider {
             URI uri = URI.create(graylogHost);
 
             Map<String, String> params = UriParser.parse(uri);
-            int connectionTimeMs = (int) UriParser.getTimeAsMs(params, GelfTCPSender.CONNECTION_TIMEOUT,
-                    defaultTimeoutMs);
+            int connectionTimeMs = (int) UriParser.getTimeAsMs(params, GelfTCPSender.CONNECTION_TIMEOUT, defaultTimeoutMs);
             int readTimeMs = (int) UriParser.getTimeAsMs(params, GelfTCPSender.READ_TIMEOUT, defaultTimeoutMs);
             int deliveryAttempts = UriParser.getInt(params, GelfTCPSender.RETRIES, 1);
             boolean keepAlive = UriParser.getString(params, GelfTCPSender.KEEPALIVE, false);
@@ -52,7 +51,9 @@ public class DefaultGelfSenderProvider implements GelfSenderProvider {
             String udpGraylogHost = UriParser.getHost(uri);
             return new GelfUDPSender(udpGraylogHost, port, configuration.getErrorReporter());
         } else if (graylogHost.startsWith("http")) {
-            return new GelfHTTPSender(graylogHost, port, configuration.getErrorReporter(), HttpClientBuilder.create());
+            String graylogHostWithDefaultPort = addDefaultPortIfMissing(graylogHost, String.valueOf(port));
+            URL url = new URL(graylogHostWithDefaultPort);
+            return new GelfHTTPSender(url, configuration.getErrorReporter());
 
         } else {
             return new GelfUDPSender(graylogHost, port, configuration.getErrorReporter());

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
@@ -1,0 +1,75 @@
+package biz.paluch.logging.gelf.intern.sender;
+
+import biz.paluch.logging.gelf.intern.Closer;
+import biz.paluch.logging.gelf.intern.ErrorReporter;
+import biz.paluch.logging.gelf.intern.GelfMessage;
+import biz.paluch.logging.gelf.intern.GelfSender;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static biz.paluch.logging.gelf.GelfUtil.addDefaultPortIfMissing;
+
+/**
+ * Created by https://github.com/salex89
+ */
+public class GelfHTTPSender implements GelfSender {
+
+    final private String uri;
+    final private int port;
+    final private ErrorReporter errorReporter;
+    final private CloseableHttpClient httpClient;
+
+
+    public GelfHTTPSender(String uri, int port, ErrorReporter errorReporter, HttpClientBuilder builder) {
+
+        this.uri = addDefaultPortIfMissing(uri, String.valueOf(port));
+        this.port = port;
+        this.errorReporter = errorReporter;
+
+
+        httpClient = builder.build();
+    }
+
+    @Override
+    public boolean sendMessage(GelfMessage message) {
+
+        CloseableHttpResponse httpResponse = null;
+        try {
+            HttpPost post = new HttpPost(uri);
+            String messageJson = message.toJson();
+            post.setEntity(new StringEntity(messageJson));
+            httpResponse = httpClient.execute(post);
+            int responseStatusCode = httpResponse.getStatusLine().getStatusCode();
+            if (responseStatusCode == 202) {
+                return true;
+            } else {
+                errorReporter.reportError("HTTP responded with non-202 status code: " +
+                        responseStatusCode, new IOException("Cannot send data to " + uri + ":" + port));
+            }
+        } catch (UnsupportedEncodingException e) {
+            errorReporter.reportError(e.getMessage(), new IOException("Cannot create HTTP GELF message to ", e));
+        } catch (ClientProtocolException e) {
+            errorReporter.reportError(e.getMessage(), new IOException("Cannot send data to " + uri + ":" + port, e));
+        } catch (IOException e) {
+            errorReporter.reportError(e.getMessage(), new IOException("Cannot send data to " + uri + ":" + port, e));
+        } finally {
+            if (httpResponse != null)
+                Closer.close(httpResponse);
+        }
+        return false;
+    }
+
+    @Override
+    public void close() {
+        Closer.close(httpClient);
+    }
+}

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
@@ -1,75 +1,51 @@
 package biz.paluch.logging.gelf.intern.sender;
 
-import biz.paluch.logging.gelf.intern.Closer;
 import biz.paluch.logging.gelf.intern.ErrorReporter;
 import biz.paluch.logging.gelf.intern.GelfMessage;
 import biz.paluch.logging.gelf.intern.GelfSender;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import static biz.paluch.logging.gelf.GelfUtil.addDefaultPortIfMissing;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 /**
  * Created by https://github.com/salex89
  */
 public class GelfHTTPSender implements GelfSender {
 
-    final private String uri;
-    final private int port;
     final private ErrorReporter errorReporter;
-    final private CloseableHttpClient httpClient;
+    final private URL url;
+    private HttpURLConnection connection = null;
+    private int HTTP_ACCEPTED_STATUS = 202;
 
-
-    public GelfHTTPSender(String uri, int port, ErrorReporter errorReporter, HttpClientBuilder builder) {
-
-        this.uri = addDefaultPortIfMissing(uri, String.valueOf(port));
-        this.port = port;
+    public GelfHTTPSender(URL url, ErrorReporter errorReporter) {
         this.errorReporter = errorReporter;
-
-
-        httpClient = builder.build();
+        this.url = url;
     }
 
-    @Override
-    public boolean sendMessage(GelfMessage message) {
-
-        CloseableHttpResponse httpResponse = null;
+    @Override public boolean sendMessage(GelfMessage message) {
         try {
-            HttpPost post = new HttpPost(uri);
-            String messageJson = message.toJson();
-            post.setEntity(new StringEntity(messageJson));
-            httpResponse = httpClient.execute(post);
-            int responseStatusCode = httpResponse.getStatusLine().getStatusCode();
-            if (responseStatusCode == 202) {
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            OutputStream outputStream = connection.getOutputStream();
+            outputStream.write(message.toJson().getBytes());
+            outputStream.close();
+            int responseCode = connection.getResponseCode();
+            if (responseCode == HTTP_ACCEPTED_STATUS) {
                 return true;
             } else {
-                errorReporter.reportError("HTTP responded with non-202 status code: " +
-                        responseStatusCode, new IOException("Cannot send data to " + uri + ":" + port));
+                errorReporter.reportError("Server responded with unexpected status code: ", null);
             }
-        } catch (UnsupportedEncodingException e) {
-            errorReporter.reportError(e.getMessage(), new IOException("Cannot create HTTP GELF message to ", e));
-        } catch (ClientProtocolException e) {
-            errorReporter.reportError(e.getMessage(), new IOException("Cannot send data to " + uri + ":" + port, e));
         } catch (IOException e) {
-            errorReporter.reportError(e.getMessage(), new IOException("Cannot send data to " + uri + ":" + port, e));
-        } finally {
-            if (httpResponse != null)
-                Closer.close(httpResponse);
+            errorReporter.reportError("Error when sending log message", e);
         }
         return false;
     }
 
-    @Override
-    public void close() {
-        Closer.close(httpClient);
+    @Override public void close() {
+        //disconnecting HttpURLConnection here to avoid underlying premature underlying Socket being closed.
+        if (connection != null)
+            connection.disconnect();
     }
 }

--- a/src/test/java/biz/paluch/logging/gelf/GelfInboundHTTPHandler.java
+++ b/src/test/java/biz/paluch/logging/gelf/GelfInboundHTTPHandler.java
@@ -1,0 +1,81 @@
+package biz.paluch.logging.gelf;
+
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.*;
+import io.netty.util.CharsetUtil;
+import org.json.simple.JSONValue;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by aleksandar on 3/12/16.
+ */
+public class GelfInboundHTTPHandler extends SimpleChannelInboundHandler<Object> {
+    private List<Object> values = new ArrayList<Object>();
+    private HttpRequest httpRequest;
+    private HttpContent httpContent;
+    private HttpResponseStatus responseStatus = HttpResponseStatus.ACCEPTED;
+
+    private final StringBuilder contentBuffer = new StringBuilder();
+
+    @Override protected void channelRead0(ChannelHandlerContext channelHandlerContext, Object message) throws Exception {
+
+        resetState();
+        if (message instanceof HttpRequest) {
+            httpRequest = (HttpRequest) message;
+        }
+        if (message instanceof HttpContent) {
+            httpContent = (HttpContent) message;
+            contentBuffer.append(httpContent.content().toString(CharsetUtil.UTF_8));
+            if (message instanceof LastHttpContent) {
+                Object parsedContent = JSONValue.parse(contentBuffer.toString());
+                synchronized (values) {
+                    values.add(parsedContent);
+                }
+                writeResponse(channelHandlerContext);
+                closeConnection(channelHandlerContext);
+            }
+        }
+
+    }
+
+    private void resetState() {
+        this.values.clear();
+        this.httpContent = null;
+        this.httpRequest = null;
+    }
+
+    private void closeConnection(ChannelHandlerContext channelHandlerContext) {
+        channelHandlerContext.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private void writeResponse(ChannelHandlerContext ctx) {
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, responseStatus);
+        ctx.write(response);
+    }
+
+    public List<Object> getValues() {
+        return values;
+    }
+
+    public String getUri() {
+        return httpRequest.getUri();
+    }
+
+    public HttpMethod getMethod() {
+        return httpRequest.getMethod();
+    }
+
+    public void setReturnStatus(HttpResponseStatus status) {
+        this.responseStatus = status;
+    }
+}

--- a/src/test/java/biz/paluch/logging/gelf/GelfInboundHTTPInitializer.java
+++ b/src/test/java/biz/paluch/logging/gelf/GelfInboundHTTPInitializer.java
@@ -1,0 +1,30 @@
+package biz.paluch.logging.gelf;
+
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.*;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+
+/**
+ * Created by aleksandar on 3/12/16.
+ */
+public class GelfInboundHTTPInitializer extends ChannelInitializer<SocketChannel> {
+    protected GelfInboundHTTPHandler handler;
+
+    public GelfInboundHTTPInitializer() {
+        handler = new GelfInboundHTTPHandler();
+    }
+
+    @Override protected void initChannel(SocketChannel socketChannel) throws Exception {
+        ChannelPipeline pipeline = socketChannel.pipeline();
+        pipeline.addLast(new HttpRequestDecoder());
+        pipeline.addLast(new HttpObjectAggregator(1048576));
+        pipeline.addLast(new HttpResponseEncoder());
+        pipeline.addLast(handler);
+    }
+
+    public GelfInboundHTTPHandler getHandler() {
+        return handler;
+    }
+}

--- a/src/test/java/biz/paluch/logging/gelf/GelfUtilTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/GelfUtilTest.java
@@ -1,6 +1,7 @@
 package biz.paluch.logging.gelf;
 
 import static org.junit.Assert.assertEquals;
+
 import biz.paluch.logging.gelf.intern.GelfMessage;
 import biz.paluch.logging.gelf.jboss7.JBoss7JulLogEvent;
 import org.jboss.logmanager.ExtLogRecord;
@@ -40,5 +41,11 @@ public class GelfUtilTest {
 
         assertEquals("12sec", message.getAdditonalFields().get(GelfUtil.MDC_REQUEST_DURATION));
 
+    }
+
+    @Test
+    public void addDefaultPortIfMissing() {
+        String url = GelfUtil.addDefaultPortIfMissing("http://example.com/foo", String.valueOf(1234));
+        assertEquals("http://example.com:1234/foo", url);
     }
 }

--- a/src/test/java/biz/paluch/logging/gelf/GelfUtilTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/GelfUtilTest.java
@@ -13,8 +13,7 @@ import java.util.logging.Level;
 
 public class GelfUtilTest {
 
-    @Test
-    public void testProfilingString() throws Exception {
+    @Test public void testProfilingString() throws Exception {
 
         Map mdcMap = new HashMap();
         mdcMap.put(GelfUtil.MDC_REQUEST_START_MS, "" + (System.currentTimeMillis() - 12000));
@@ -28,8 +27,7 @@ public class GelfUtilTest {
 
     }
 
-    @Test
-    public void testProfilingLong() throws Exception {
+    @Test public void testProfilingLong() throws Exception {
 
         Map mdcMap = new HashMap();
         mdcMap.put(GelfUtil.MDC_REQUEST_START_MS, (System.currentTimeMillis() - 12000));
@@ -43,9 +41,10 @@ public class GelfUtilTest {
 
     }
 
-    @Test
-    public void addDefaultPortIfMissing() {
+    @Test public void addDefaultPortIfMissing() {
         String url = GelfUtil.addDefaultPortIfMissing("http://example.com/foo", String.valueOf(1234));
         assertEquals("http://example.com:1234/foo", url);
+        String url2 = GelfUtil.addDefaultPortIfMissing("http://example.com:8080/foo", String.valueOf(1234));
+        assertEquals("http://example.com:8080/foo", url2);
     }
 }

--- a/src/test/java/biz/paluch/logging/gelf/NettyLocalHTTPServer.java
+++ b/src/test/java/biz/paluch/logging/gelf/NettyLocalHTTPServer.java
@@ -1,0 +1,52 @@
+package biz.paluch.logging.gelf;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:mpaluch@paluch.biz">Mark Paluch</a>
+ * @since 10.11.13 10:30
+ */
+public class NettyLocalHTTPServer {
+
+    private int port = 19393;
+    private EventLoopGroup group = new NioEventLoopGroup();
+    private GelfInboundHTTPInitializer handlerInitializer = new GelfInboundHTTPInitializer();
+    private Class<? extends Channel> channelClass = NioServerSocketChannel.class;
+
+    private ChannelFuture f;
+
+    public NettyLocalHTTPServer() {
+    }
+
+    public void run() throws Exception {
+
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(group);
+        b.channel((Class) channelClass).childHandler(handlerInitializer);
+        f = b.bind(port).sync();
+    }
+
+    public void close() {
+        f.channel().close();
+        f = null;
+    }
+
+    public List<Object> getJsonValues() {
+        return handlerInitializer.getHandler().getValues();
+    }
+
+    public void setReturnStatus(HttpResponseStatus status) {
+        handlerInitializer.getHandler().setReturnStatus(status);
+    }
+
+    public GelfInboundHTTPInitializer getHandlerInitializer() {
+        return handlerInitializer;
+    }
+}

--- a/src/test/java/biz/paluch/logging/gelf/NettyLocalServer.java
+++ b/src/test/java/biz/paluch/logging/gelf/NettyLocalServer.java
@@ -2,12 +2,7 @@ package biz.paluch.logging.gelf;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.AdaptiveRecvByteBufAllocator;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ServerChannel;
+import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 
 import java.util.List;

--- a/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSenderTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSenderTest.java
@@ -33,28 +33,27 @@ import static org.mockito.Mockito.*;
 public class GelfHTTPSenderTest {
 
     private NettyLocalHTTPServer server;
-
+    private GelfHTTPSender sender;
     @Mock ErrorReporter errorReporter;
 
-    @Before public void setUpClass() throws Exception {
+    @Before public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
         server = new NettyLocalHTTPServer();
         server.run();
+        String uri = "http://127.0.0.1:19393";
+        sender = new GelfHTTPSender(new URL(uri), errorReporter);
 
     }
 
-    @After public void tearDownClass() {
+    @After public void tearDown() {
         server.close();
-    }
-
-    @Before public void setUp() throws IOException {
-        MockitoAnnotations.initMocks(this);
+        sender.close();
     }
 
     @Test public void sendMessageTest() throws IOException {
 
         server.setReturnStatus(HttpResponseStatus.ACCEPTED);
-        String uri = "http://127.0.0.1:19393";
-        GelfHTTPSender sender = new GelfHTTPSender(new URL(uri), errorReporter);
+
         GelfMessage gelfMessage = new GelfMessage("shortMessage", "fullMessage", 12121l, "WARNING");
         boolean success = sender.sendMessage(gelfMessage);
         assertTrue(success);
@@ -66,6 +65,7 @@ public class GelfHTTPSenderTest {
         assertEquals(gelfMessage.getFullMessage(), messageJson.get("full_message"));
         assertEquals(gelfMessage.getTimestamp(), messageJson.get("timestamp"));
         assertEquals(gelfMessage.getLevel(), messageJson.get("level"));
+
     }
 
     @Test public void sendMessageFailureTest() throws IOException {

--- a/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSenderTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSenderTest.java
@@ -1,0 +1,85 @@
+package biz.paluch.logging.gelf.intern.sender;
+
+import biz.paluch.logging.gelf.intern.ErrorReporter;
+import biz.paluch.logging.gelf.intern.GelfMessage;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.util.EntityUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * (c) Alekandar - https://github.com/salex89
+ */
+
+public class GelfHTTPSenderTest {
+
+
+    @Mock
+    HttpClientBuilder builder;
+    @Mock
+    CloseableHttpClient closeableHttpClient;
+    @Mock
+    CloseableHttpResponse closeableHttpResponse;
+    @Mock
+    ErrorReporter errorReporter;
+
+    @Before
+    public void prepareMocks() throws IOException {
+        MockitoAnnotations.initMocks(this);
+//        when(closeableHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 202, "Accepted"));
+//        when(builder.build()).thenReturn(closeableHttpClient);
+//        when(closeableHttpClient.execute((HttpUriRequest) any())).thenReturn(closeableHttpResponse);
+    }
+
+    @Test
+    public void sendMessageTest() throws IOException {
+        when(closeableHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 202, "Accepted"));
+        when(builder.build()).thenReturn(closeableHttpClient);
+        when(closeableHttpClient.execute((HttpUriRequest) any())).thenReturn(closeableHttpResponse);
+
+        String uri = "http://192.168.0.100/gelf";
+        GelfHTTPSender sender = new GelfHTTPSender(uri, 12201, errorReporter, builder);
+        GelfMessage gelfMessage = new GelfMessage();
+        boolean success = sender.sendMessage(gelfMessage);
+        verify(builder, times(1)).build();
+        assertTrue(success);
+        verifyZeroInteractions(errorReporter);
+        ArgumentCaptor<HttpPost> postCaptor = ArgumentCaptor.forClass(HttpPost.class);
+        verify(closeableHttpClient).execute(postCaptor.capture());
+        HttpPost executedPost = postCaptor.getValue();
+        assertEquals("http://192.168.0.100:12201/gelf", executedPost.getURI().toString());
+        assertEquals(gelfMessage.toJson(), EntityUtils.toString(executedPost.getEntity()));
+    }
+
+    @Test
+    public void sendMessageTestIncorrectUrl() throws IOException {
+        String uri = "adda";
+        GelfHTTPSender sender = new GelfHTTPSender(uri, 12201, errorReporter, HttpClientBuilder.create());
+        GelfMessage gelfMessage = new GelfMessage();
+        boolean success = sender.sendMessage(gelfMessage);
+        assertFalse(success);
+//        verifyZeroInteractions(errorReporter);
+//        ArgumentCaptor<HttpPost> postCaptor = ArgumentCaptor.forClass(HttpPost.class);
+//        verify(closeableHttpClient).execute(postCaptor.capture());
+//        HttpPost executedPost = postCaptor.getValue();
+//        assertEquals("http://192.168.0.100:12201/gelf", executedPost.getURI().toString());
+//        assertEquals(gelfMessage.toJson(), EntityUtils.toString(executedPost.getEntity()));
+    }
+}

--- a/src/test/resources/logback-gelf-with-http.xml
+++ b/src/test/resources/logback-gelf-with-http.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration debug="true">
+    <contextName>test</contextName>
+    <jmxConfigurator/>
+
+    <appender name="GELF" class="biz.paluch.logging.gelf.logback.GelfLogbackAppender">
+        <graylogHost>http://localhost:19393/foo/bar</graylogHost>
+        <graylogPort>19393</graylogPort>
+        <facility>java-test</facility>
+        <extractStackTrace>true</extractStackTrace>
+        <filterStackTrace>true</filterStackTrace>
+        <mdcProfiling>true</mdcProfiling>
+        <timestampPattern>yyyy-MM-dd HH:mm:ss,SSSS</timestampPattern>
+        <maximumMessageSize>8192</maximumMessageSize>
+        <additionalFields>fieldName1=fieldValue1,fieldName2=fieldValue2,myOriginHost=${HOSTNAME}</additionalFields>
+        <mdcFields>mdcField1,mdcField2</mdcFields>
+        <originHost>1.2.3.4</originHost>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="GELF"/>
+    </root>
+</configuration>


### PR DESCRIPTION
#### Outline
Added HTTP Sender, for situations when the log manager is on a remote location or behind a proxy. Currently TLS and authentication is not supported, only log submission. TLS is the next step.

#### Motivation
The motivation is to use Graylog for remote logging, with Android devices, IoT and such.

#### Added configuration
As for the HTTP sender configuration, the host is the complete path to the log manager (i.e Graylog) endpoint, like `http://192.168.0.1:12201/gelf` . If the port is not added to the host, the one supplied in the configuration file will be inserted into the host. I would gladly document this example, when I am informed where to put it :-) .

#### Questions and issues
Regarding TLS and auth, additional configuration is needed (not sure which fields for now). I would like to consult with the author, which is the best way to do it? Should new configuration fields be added, available in all of the formats, hence, modifying all of the parsers, or some other way? I have noticed that the `GelfSenderConfiguration` has the method `Map<String, Object> getSpecificConfigurations();`, and I suppose this is the way to go, based on the design. However, no example is provided how is this bound to the configuration files, and I'm not sure is it.

Looking forward to continuing this,
Aleksandar