### PR TITLE
Always check if JUL message is a resource bundle key and translate if so

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/jul/JulLogEvent.java
+++ b/src/main/java/biz/paluch/logging/gelf/jul/JulLogEvent.java
@@ -65,10 +65,12 @@ public class JulLogEvent implements LogEvent {
         if (message == null) {
             message = "";
         }
+        
+        if (record.getResourceBundle() != null && record.getResourceBundle().containsKey(message)) {
+            message = record.getResourceBundle().getString(message);
+        }
+        
         if (parameters != null && parameters.length > 0) {
-            if (record.getResourceBundle() != null && record.getResourceBundle().containsKey(record.getMessage())) {
-                message = record.getResourceBundle().getString(record.getMessage());
-            }
             String originalMessage = message;
 
             // by default, using {0}, {1}, etc. -> MessageFormat

--- a/src/test/java/biz/paluch/logging/gelf/jul/GelfLogHandlerTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/jul/GelfLogHandlerTest.java
@@ -59,6 +59,16 @@ public class GelfLogHandlerTest {
 
         assertExpectedMessage(expectedMessage);
     }
+    
+    @Test
+    public void testWithResourceBundleFormattingWithoutParameters() throws Exception {
+        Logger logger = Logger.getLogger(getClass().getName(), "messages");
+        String expectedMessage = "no parameter supplied";
+
+        logger.log(Level.INFO, "message.format.withoutParameter");
+
+        assertExpectedMessage(expectedMessage);
+    }
 
     @Test
     public void testWithResourceBundleFormattingMalformed1() throws Exception {

--- a/src/test/resources/messages.properties
+++ b/src/test/resources/messages.properties
@@ -2,3 +2,4 @@ message.format.curly.brackets=params {0} and {1}
 message.format.fail1=params {a}
 message.format.fail2=params %d
 message.format.percentages=params %s and %d
+message.format.withoutParameter=no parameter supplied


### PR DESCRIPTION
The case where a JUL message specifies a bundle key was considered only
for the case where parameters were supplied with the message, but not
if no parameters were supplied.

The translation is moved outside the parameter handling block and so
applied to all messages.

Closes: #82