### PR TITLE
Corrupted gelf messages with TCP sender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,19 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfTCPSenderTest.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfTCPSenderTest.java
@@ -9,12 +9,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import java.net.ConnectException;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
+import java.io.InputStream;
+import java.net.*;
+import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -129,6 +138,124 @@ public class GelfTCPSenderTest {
 
         listener.close();
         spy.close();
+    }
+
+    @Test
+    public void socketSendBufferOverflowTest() throws Exception {
+
+        final int TEST_DURATION_MILLIS = 3000;
+
+        int port = randomPort();
+
+        // some payload to increase size of GelfMessage
+        final GelfMessage gelfMessage = new GelfMessage("" +
+                "----------------------------------------------------------------------------------------------------" +
+                "----------------------------------------------------------------------------------------------------" +
+                "----------------------------------------------------------------------------------------------------" +
+                "----------------------------------------------------------------------------------------------------" +
+                "----------------------------------------------------------------------------------------------------" +
+                "", "" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "====================================================================================================" +
+                "", 1000, "info");
+        gelfMessage.setHost("host");
+
+        final ByteBuffer referenceMessage = gelfMessage.toTCPBuffer();
+        final byte[] referenceMessageArray = referenceMessage.array();
+
+        final AtomicInteger readBytesCount = new AtomicInteger();
+        final AtomicLong lastReadTs = new AtomicLong();
+        final AtomicBoolean running = new AtomicBoolean(true);
+
+        final long startTs = System.currentTimeMillis();
+
+        // local server, reads all data and checks gelf messages stream integrity
+        final ServerSocket listener = new ServerSocket(port);
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                byte[] arr = new byte[1024 * 1024];
+                try {
+                    Socket socket = listener.accept();
+                    InputStream inputStream = socket.getInputStream();
+
+                    int currIdx = 0;
+                    int len;
+                    while ((len = inputStream.read(arr)) != -1) {
+                        long currentTimeMillis = System.currentTimeMillis();
+                        if (currentTimeMillis > startTs + TEST_DURATION_MILLIS) {
+                            running.set(false);
+                        }
+
+                        lastReadTs.set(currentTimeMillis);
+                        readBytesCount.addAndGet(len);
+
+                        // check GelfMessages integrity, stream of similar gelf messages
+                        for (int i = 0; i < len; i++) {
+                            if (referenceMessageArray[currIdx] != arr[i]) {
+                                running.set(false);
+                                Assert.fail("inconsistent message: '" + new String(arr, Math.max(0, i - 20),
+                                        Math.min(40, len)) + "'");
+                            }
+
+                            if (++currIdx == referenceMessageArray.length) {
+                                currIdx = 0;
+                            }
+                        }
+                        // message processing delay
+                        Thread.sleep(10);
+                    }
+                } catch (IOException e) {
+                } catch (InterruptedException e) {
+                }
+            }
+        });
+        thread.start();
+
+        // log senders
+        final GelfTCPSender tcpSender = new GelfTCPSender("127.0.0.1", port, 1000, 1000, errorReporter);
+
+        final AtomicInteger sendMessagesCount = new AtomicInteger();
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                while (running.get()) {
+                    tcpSender.sendMessage(gelfMessage);
+                    sendMessagesCount.incrementAndGet();
+                }
+            }
+        };
+        int writersCount = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
+        ExecutorService executorService = Executors.newFixedThreadPool(writersCount);
+        List<Future> futures = new ArrayList<Future>();
+        for (int i = 0; i < writersCount; i++) {
+            futures.add(executorService.submit(runnable));
+        }
+
+        // waiting writer tasks to complete
+        for (Future future : futures) {
+            future.get();
+        }
+        tcpSender.close();
+        executorService.shutdown();
+
+        // waiting listener completes reading, 1 sec idle state
+        while (System.currentTimeMillis() - lastReadTs.get() < 1000) {
+            Thread.sleep(100);
+        }
+
+        listener.close();
+
+        int msgLen = referenceMessage.capacity();
+        Assert.assertEquals(sendMessagesCount.get() * msgLen, readBytesCount.get());
     }
 
     @Test


### PR DESCRIPTION
On high loads some log messages are corrupted or lost. Writed reproducable test.

Environment: java version "1.8.0_102"; logstash-gelf-1.10.0; logback 1.1.7; graylog.

I'm using logback with logstash-gelf-1.10.0 appender, configured using tcp protocol.
Problem is still reproducable on logstash-gelf-1.11.0-SNAPSHOT.

Logback.xml appender config:
```
<appender name="GELF" class="biz.paluch.logging.gelf.logback.GelfLogbackAppender">
    <host>tcp:${graylogHost}</host>
    <port>12201</port>
    <version>1.1</version>
    <facility>${appName}</facility>

    <extractStackTrace>true</extractStackTrace>
    <filterStackTrace>true</filterStackTrace>

    <timestampPattern>yyyy-MM-dd_HH:mm:ss.SSS</timestampPattern>
    <maximumMessageSize>8192</maximumMessageSize>
</appender>
```