### PR TITLE
Add missing Log4j2 plugin configuration

### DIFF
--- a/src/site/markdown/examples/log4j-2.x.md
+++ b/src/site/markdown/examples/log4j-2.x.md
@@ -67,7 +67,7 @@ host{["fqdn"<br/>"simple"<br/>"address"]} | Outputs either the FQDN hostname, th
 
 XML:
     
-    <Configuration>
+    <Configuration packages="biz.paluch.logging.gelf.log4j2">
         <Appenders>
             <Gelf name="gelf" host="udp:localhost" port="12201" version="1.0" extractStackTrace="true"
                   filterStackTrace="true" mdcProfiling="true" includeFullMdc="true" maximumMessageSize="8192" 


### PR DESCRIPTION
The example XML was missing plugin search configuration as described at:
https://logging.apache.org/log4j/2.x/manual/configuration.html#ConfigurationSyntax

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/logstash-gelf/blob/master/.github/CONTRIBUTING.md).
- [ ] You use the code formatters provided [here](https://github.com/mp911de/logstash-gelf/blob/master/as7formatter.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.