### PR TITLE
Adds authorization basic to HTTP requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,6 +435,13 @@
             <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.9</version>
+        </dependency>
+
     </dependencies>
 
     <reporting>

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
@@ -1,13 +1,14 @@
 package biz.paluch.logging.gelf.intern.sender;
 
+import biz.paluch.logging.gelf.intern.ErrorReporter;
+import biz.paluch.logging.gelf.intern.GelfMessage;
+import biz.paluch.logging.gelf.intern.GelfSender;
+import com.sun.xml.internal.messaging.saaj.util.Base64;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-
-import biz.paluch.logging.gelf.intern.ErrorReporter;
-import biz.paluch.logging.gelf.intern.GelfMessage;
-import biz.paluch.logging.gelf.intern.GelfSender;
 
 /**
  * HTTP-based Gelf sender. This sender uses Java's HTTP client to {@code POST} JSON Gelf messages to an endpoint.
@@ -51,6 +52,10 @@ public class GelfHTTPSender implements GelfSender {
         try {
 
             connection = (HttpURLConnection) url.openConnection();
+            if (url.getUserInfo() != null) {
+                String basicAuth = "Basic " + new String(Base64.encode(url.getUserInfo().getBytes()));
+                connection.setRequestProperty("Authorization", basicAuth);
+            }
             connection.setConnectTimeout(connectTimeoutMs);
             connection.setReadTimeout(readTimeoutMs);
             connection.setDoOutput(true);

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
@@ -3,13 +3,11 @@ package biz.paluch.logging.gelf.intern.sender;
 import biz.paluch.logging.gelf.intern.ErrorReporter;
 import biz.paluch.logging.gelf.intern.GelfMessage;
 import biz.paluch.logging.gelf.intern.GelfSender;
-import com.sun.xml.internal.messaging.saaj.util.Base64;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-
 /**
  * HTTP-based Gelf sender. This sender uses Java's HTTP client to {@code POST} JSON Gelf messages to an endpoint.
  *
@@ -53,7 +51,7 @@ public class GelfHTTPSender implements GelfSender {
 
             connection = (HttpURLConnection) url.openConnection();
             if (url.getUserInfo() != null) {
-                String basicAuth = "Basic " + new String(Base64.encode(url.getUserInfo().getBytes()));
+                String basicAuth = "Basic " + org.apache.commons.codec.binary.Base64.encodeBase64String(url.getUserInfo().getBytes());
                 connection.setRequestProperty("Authorization", basicAuth);
             }
             connection.setConnectTimeout(connectTimeoutMs);


### PR DESCRIPTION
With this PR you are able to send a HTTP Auth Basic Header. Simply set http://user:password@graylog.url as config url and the header will be created. 

For those who want to secure the graylog endpoint when using e.g. nginx