### PR TITLE
Fix a memory leak in GelfUDPSender

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfUDPSender.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfUDPSender.java
@@ -17,21 +17,21 @@ import biz.paluch.logging.gelf.intern.GelfSender;
  */
 public class GelfUDPSender extends AbstractNioSender<DatagramChannel> implements GelfSender {
 
+    private static final ThreadLocal<ByteBuffer> WRITE_BUFFERS = new ThreadLocal<ByteBuffer>() {
+        @Override
+        protected ByteBuffer initialValue() {
+            return ByteBuffer.allocateDirect(INITIAL_BUFFER_SIZE);
+        }
+    };
+
+    private static final ThreadLocal<ByteBuffer> TEMP_BUFFERS = new ThreadLocal<ByteBuffer>() {
+        @Override
+        protected ByteBuffer initialValue() {
+            return ByteBuffer.allocateDirect(INITIAL_BUFFER_SIZE);
+        }
+    };
+
     private final Object ioLock = new Object();
-
-    private final ThreadLocal<ByteBuffer> writeBuffers = new ThreadLocal<ByteBuffer>() {
-        @Override
-        protected ByteBuffer initialValue() {
-            return ByteBuffer.allocateDirect(INITIAL_BUFFER_SIZE);
-        }
-    };
-
-    private final ThreadLocal<ByteBuffer> tempBuffers = new ThreadLocal<ByteBuffer>() {
-        @Override
-        protected ByteBuffer initialValue() {
-            return ByteBuffer.allocateDirect(INITIAL_BUFFER_SIZE);
-        }
-    };
 
     public GelfUDPSender(String host, int port, ErrorReporter errorReporter) throws IOException {
         super(errorReporter, host, port);
@@ -44,7 +44,7 @@ public class GelfUDPSender extends AbstractNioSender<DatagramChannel> implements
             return sendDatagrams(message.toUDPBuffers());
         }
 
-        return sendDatagrams(GelfBuffers.toUDPBuffers(message, writeBuffers, tempBuffers));
+        return sendDatagrams(GelfBuffers.toUDPBuffers(message, WRITE_BUFFERS, TEMP_BUFFERS));
     }
 
     private boolean sendDatagrams(ByteBuffer[] bytesList) {


### PR DESCRIPTION
ThreadLocal instances should be defined as `static` so that
the ThreadLocal pool is shared between all instances of a class.
With a non-static ThreadLocal instance, each instance of the
GelfUDPSender will spin up a new ThreadLocal instance, which
will not know about the other ThreadLocal instances, and
will reinitialize the ByteBuffer even if another instance in the
same thread has already done so.

We were seeing out of memory errors in some of our particularly
threading-heavy services and traced it back to this class.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/mp911de/logstash-gelf/blob/master/.github/CONTRIBUTING.md).
- [X] You use the code formatters provided [here](https://github.com/mp911de/logstash-gelf/blob/master/as7formatter.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [N/A] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->