### PR TITLE
Check value instead of name for not null when collecting MDC entries

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/logback/LogbackLogEvent.java
+++ b/src/main/java/biz/paluch/logging/gelf/logback/LogbackLogEvent.java
@@ -181,7 +181,7 @@ class LogbackLogEvent implements LogEvent {
 
         for (String mdcName : matchingMdcNames) {
             String mdcValue = getMdcValue(mdcName);
-            if (mdcName != null) {
+            if (mdcValue != null) {
                 result.setValue(mdcName, mdcValue);
             }
         }

--- a/src/test/java/biz/paluch/logging/gelf/logback/GelfLogbackAppenderDynamicMdcTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/logback/GelfLogbackAppenderDynamicMdcTests.java
@@ -79,26 +79,25 @@ public class GelfLogbackAppenderDynamicMdcTests {
         assertThat(gelfMessage.getAdditonalFields()).doesNotContainKey(MY_MDC_WITH_SUFFIX2);
 
     }
-    
+
     @Test
     public void testWithMdcPrefix() throws Exception {
-        
+
         Logger logger = lc.getLogger(getClass());
         MDC.put(MDC_MY_MDC, VALUE_1);
         MDC.put(MY_MDC_WITH_SUFFIX1, VALUE_2);
         MDC.put(MY_MDC_WITH_SUFFIX2, VALUE_3);
-        
+
         logger.info(LOG_MESSAGE);
         assertThat(GelfTestSender.getMessages()).hasSize(1);
-        
+
         GelfMessage gelfMessage = GelfTestSender.getMessages().get(0);
-        
+
         assertThat(gelfMessage.getField(MDC_MY_MDC)).isEqualTo(VALUE_1);
         assertThat(gelfMessage.getField(MY_MDC_WITH_SUFFIX1)).isEqualTo(VALUE_2);
         assertThat(gelfMessage.getField(MY_MDC_WITH_SUFFIX2)).isEqualTo(VALUE_3);
-        
+
     }
-    
 
     @Test
     public void testWithMdcRegex() throws Exception {

--- a/src/test/java/biz/paluch/logging/gelf/logback/GelfLogbackAppenderDynamicMdcTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/logback/GelfLogbackAppenderDynamicMdcTests.java
@@ -63,12 +63,11 @@ public class GelfLogbackAppenderDynamicMdcTests {
     }
 
     @Test
-    public void testWithMdcPrefix() throws Exception {
+    public void testWithNullValue() throws Exception {
 
         Logger logger = lc.getLogger(getClass());
         MDC.put(MDC_MY_MDC, VALUE_1);
-        MDC.put(MY_MDC_WITH_SUFFIX1, VALUE_2);
-        MDC.put(MY_MDC_WITH_SUFFIX2, VALUE_3);
+        MDC.put(MY_MDC_WITH_SUFFIX1, null);
 
         logger.info(LOG_MESSAGE);
         assertThat(GelfTestSender.getMessages()).hasSize(1);
@@ -76,10 +75,30 @@ public class GelfLogbackAppenderDynamicMdcTests {
         GelfMessage gelfMessage = GelfTestSender.getMessages().get(0);
 
         assertThat(gelfMessage.getField(MDC_MY_MDC)).isEqualTo(VALUE_1);
-        assertThat(gelfMessage.getField(MY_MDC_WITH_SUFFIX1)).isEqualTo(VALUE_2);
-        assertThat(gelfMessage.getField(MY_MDC_WITH_SUFFIX2)).isEqualTo(VALUE_3);
+        assertThat(gelfMessage.getAdditonalFields()).doesNotContainKey(MY_MDC_WITH_SUFFIX1);
+        assertThat(gelfMessage.getAdditonalFields()).doesNotContainKey(MY_MDC_WITH_SUFFIX2);
 
     }
+    
+    @Test
+    public void testWithMdcPrefix() throws Exception {
+        
+        Logger logger = lc.getLogger(getClass());
+        MDC.put(MDC_MY_MDC, VALUE_1);
+        MDC.put(MY_MDC_WITH_SUFFIX1, VALUE_2);
+        MDC.put(MY_MDC_WITH_SUFFIX2, VALUE_3);
+        
+        logger.info(LOG_MESSAGE);
+        assertThat(GelfTestSender.getMessages()).hasSize(1);
+        
+        GelfMessage gelfMessage = GelfTestSender.getMessages().get(0);
+        
+        assertThat(gelfMessage.getField(MDC_MY_MDC)).isEqualTo(VALUE_1);
+        assertThat(gelfMessage.getField(MY_MDC_WITH_SUFFIX1)).isEqualTo(VALUE_2);
+        assertThat(gelfMessage.getField(MY_MDC_WITH_SUFFIX2)).isEqualTo(VALUE_3);
+        
+    }
+    
 
     @Test
     public void testWithMdcRegex() throws Exception {


### PR DESCRIPTION
Only add non-null values from the MDC. This filtering is also happening in `GelfMessageAssembler.createGelfMessage` but it looks cleaner already check when collecting the values from the MDC.

Fixes #161 

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/logstash-gelf/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/logstash-gelf/blob/master/as7formatter.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->