### PR TITLE
ID with less risk of collision

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
         <logstash-gelf-release-version>1.13.0</logstash-gelf-release-version>
 
         <github.site.upload.skip>true</github.site.upload.skip>
@@ -240,8 +240,8 @@
                         <configuration>
                             <signature>
                                 <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java16</artifactId>
-                                <version>1.1</version>
+                                <artifactId>java17</artifactId>
+                                <version>1.0</version>
                             </signature>
                         </configuration>
                     </execution>

--- a/src/main/java/biz/paluch/logging/gelf/intern/GelfMessage.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/GelfMessage.java
@@ -425,11 +425,11 @@ public class GelfMessage {
         // will collide with old timestamps? Every second Graylog will evict expired messaged (5
         // seconds old) from the pool:
         // https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfChunkAggregator.java
-        // Thus, we just need six seconds which will require two bytes. Then we can spend six bytes
-        // on a random number.
+        // Thus, we just need six seconds which will require 13 bits. Then we can spend the rest on
+        // a random number.
 
-        return (getRandomLong() & 0xFFFFFFFFFFFF0000L) |
-                (getCurrentTimeMillis() & 0xFFFFL);
+        return (getRandomLong() & 0xFFFFFFFFFFFFE000L) |
+                (getCurrentTimeMillis() & 0x1FFFL);
     }
 
     long getRandomLong() {

--- a/src/main/java/biz/paluch/logging/gelf/intern/GelfMessage.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/GelfMessage.java
@@ -10,7 +10,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
 
@@ -28,8 +28,6 @@ import biz.paluch.logging.gelf.intern.ValueDiscovery.Result;
  * @see <a href="http://docs.graylog.org/en/2.0/pages/gelf.html">http://docs.graylog.org/en/2.0/pages/gelf.html</a>
  */
 public class GelfMessage {
-
-    private static final Random rand = new Random();
 
     public static final String FIELD_HOST = "host";
     public static final String FIELD_SHORT_MESSAGE = "short_message";
@@ -433,7 +431,7 @@ public class GelfMessage {
     }
 
     long getRandomLong() {
-        return rand.nextLong();
+        return ThreadLocalRandom.current().nextLong();
     }
 
     long getCurrentTimeMillis() {

--- a/src/test/java/biz/paluch/logging/gelf/intern/GelfMessageUnitTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/GelfMessageUnitTests.java
@@ -183,16 +183,16 @@ class GelfMessageUnitTests {
         GelfMessage gelfMessage = new GelfMessage() {
             @Override
             long getRandomLong() {
-                return 0x8040201008040201L;
+                return 0x804020100804A201L;
             }
 
             @Override
             long getCurrentTimeMillis() {
-                return 0x90C06030090C8683L;
+                return 0x90C06030090C1683L;
             }
         };
 
-        assertThat(gelfMessage.generateMsgId()).isEqualTo(0x8040201008048683L);
+        assertThat(gelfMessage.generateMsgId()).isEqualTo(0x804020100804B683L);
     }
 
     String toString(ByteBuffer allocate) {

--- a/src/test/java/biz/paluch/logging/gelf/intern/GelfMessageUnitTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/GelfMessageUnitTests.java
@@ -2,6 +2,8 @@ package biz.paluch.logging.gelf.intern;
 
 import static biz.paluch.logging.gelf.GelfMessageBuilder.newInstance;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -178,6 +180,26 @@ class GelfMessageUnitTests {
         }
     }
 
+    @Test
+    void testGenerateMsgId() {
+        GelfMessage gelfMessage = new GelfMessage() {
+            @Override
+            long getRandomLong() {
+                return 0x8040201008040201L;
+            }
+
+            @Override
+            short getCurrentTimeMillis() {
+                return 0x0603;
+            }
+        };
+
+        byte[] expectedBytes = { (byte) 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x06, 0x03 };
+        byte[] msgId = gelfMessage.generateMsgId();
+        assertEquals(8, msgId.length); // Just to be explicit.
+        assertArrayEquals(expectedBytes, msgId);
+    }
+
     String toString(ByteBuffer allocate) {
         if (allocate.hasArray()) {
             return new String(allocate.array(), 0, allocate.arrayOffset() + allocate.position());
@@ -249,8 +271,8 @@ class GelfMessageUnitTests {
 
         GelfMessage gelfMessage = new GelfMessage() {
             @Override
-            public int getCurrentMillis() {
-                return 1000;
+            byte[] generateMsgId() {
+                return new byte[] { (byte) 128, 64, 32, 16, 8, 4, 2, 1 };
             }
         };
 

--- a/src/test/java/biz/paluch/logging/gelf/intern/GelfMessageUnitTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/GelfMessageUnitTests.java
@@ -2,8 +2,6 @@ package biz.paluch.logging.gelf.intern;
 
 import static biz.paluch.logging.gelf.GelfMessageBuilder.newInstance;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -189,15 +187,12 @@ class GelfMessageUnitTests {
             }
 
             @Override
-            short getCurrentTimeMillis() {
-                return 0x0603;
+            long getCurrentTimeMillis() {
+                return 0x90C06030090C8683L;
             }
         };
 
-        byte[] expectedBytes = { (byte) 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x06, 0x03 };
-        byte[] msgId = gelfMessage.generateMsgId();
-        assertEquals(8, msgId.length); // Just to be explicit.
-        assertArrayEquals(expectedBytes, msgId);
+        assertThat(gelfMessage.generateMsgId()).isEqualTo(0x8040201008048683L);
     }
 
     String toString(ByteBuffer allocate) {
@@ -271,8 +266,8 @@ class GelfMessageUnitTests {
 
         GelfMessage gelfMessage = new GelfMessage() {
             @Override
-            byte[] generateMsgId() {
-                return new byte[] { (byte) 128, 64, 32, 16, 8, 4, 2, 1 };
+            long generateMsgId() {
+                return 0x8040201008048683L;
             }
         };
 

--- a/src/test/java/biz/paluch/logging/gelf/intern/PoolingGelfMessageIntegrationTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/PoolingGelfMessageIntegrationTests.java
@@ -114,8 +114,8 @@ class PoolingGelfMessageIntegrationTests {
 
         GelfMessage gelfMessage = new GelfMessage() {
             @Override
-            public int getCurrentMillis() {
-                return 1000;
+            byte[] generateMsgId() {
+                return new byte[] { (byte) 128, 64, 32, 16, 8, 4, 2, 1 };
             }
         };
 
@@ -135,8 +135,8 @@ class PoolingGelfMessageIntegrationTests {
 
         PoolingGelfMessage gelfMessage = new PoolingGelfMessage(PoolHolder.threadLocal()) {
             @Override
-            public int getCurrentMillis() {
-                return 1000;
+            byte[] generateMsgId() {
+                return new byte[] { (byte) 128, 64, 32, 16, 8, 4, 2, 1 };
             }
         };
 

--- a/src/test/java/biz/paluch/logging/gelf/intern/PoolingGelfMessageIntegrationTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/PoolingGelfMessageIntegrationTests.java
@@ -114,8 +114,8 @@ class PoolingGelfMessageIntegrationTests {
 
         GelfMessage gelfMessage = new GelfMessage() {
             @Override
-            byte[] generateMsgId() {
-                return new byte[] { (byte) 128, 64, 32, 16, 8, 4, 2, 1 };
+            long generateMsgId() {
+                return 0x8040201008048683L;
             }
         };
 
@@ -135,8 +135,8 @@ class PoolingGelfMessageIntegrationTests {
 
         PoolingGelfMessage gelfMessage = new PoolingGelfMessage(PoolHolder.threadLocal()) {
             @Override
-            byte[] generateMsgId() {
-                return new byte[] { (byte) 128, 64, 32, 16, 8, 4, 2, 1 };
+            long generateMsgId() {
+                return 0x8040201008048683L;
             }
         };
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/logstash-gelf/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/logstash-gelf/blob/master/as7formatter.xml) and have them applied to your changes. Don’t submit any formatting related changes. _Settings applied in Intellij Idea with the Eclipse Code Formatter plugin._
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

The current implementation of message ID generation seems prone to collisions in environments that produce lots of log messages very fast.
The considerations behind the implementation is documented in a rather lengthy comment. I can move the comment to the PR thread and delete it, if you like.

I took the liberty of not using assertThat() like the rest of the unit test but rather assertEquals() and assertArrayEquals(). Especially the latter will produce much more useful information in case of errors.