### PR TITLE
feat: avoid using ThreadMXBean to retrieve the name of the thread

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/jul/JulLogEvent.java
+++ b/src/main/java/biz/paluch/logging/gelf/jul/JulLogEvent.java
@@ -96,6 +96,9 @@ public class JulLogEvent implements LogEvent {
     }
 
     private String getThreadName(LogRecord record) {
+        if (record.getThreadID() == Thread.currentThread().getId()) {
+            return Thread.currentThread().getName();
+        }
 
         String cacheKey = "" + record.getThreadID();
         if (threadNameCache.containsKey(cacheKey)) {
@@ -104,13 +107,10 @@ public class JulLogEvent implements LogEvent {
 
         long threadId = record.getThreadID();
         String threadName = "" + record.getThreadID();
-        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-        for (long id : threadMXBean.getAllThreadIds()) {
-            if (id == threadId) {
-                ThreadInfo threadInfo = threadMXBean.getThreadInfo(id);
-                if (threadInfo != null) {
-                    threadName = threadInfo.getThreadName();
-                }
+        Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+        for (Thread thread : threadSet) {
+            if (thread.getId() == threadId) {
+                threadName = thread.getName();
                 break;
             }
         }


### PR DESCRIPTION
Fixes #213 

I didn't do any performance test, I would assume that as the name of the threads are cached it's OK to gather them in a slower manner.

I didn't check all the code for possible usage of JMX so this PR will not make the full library GraalVM compliant. Only the JUL Handler (as I use it) works.