### PR TITLE
Implements a fast path for jboss-manager to get the name of the thread

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/jboss7/JBoss7JulLogEvent.java
+++ b/src/main/java/biz/paluch/logging/gelf/jboss7/JBoss7JulLogEvent.java
@@ -49,6 +49,8 @@ public class JBoss7JulLogEvent extends JulLogEvent {
                 return null;
             case SourceLineNumber:
                 return getSourceLineNumber();
+            case ThreadName:
+                return this.extLogRecord.getThreadName();
         }
         return super.getValue(field);
     }


### PR DESCRIPTION
As the name of the thread is already inside the ExtLogRecord, we can just use it instead of re-calculating it.