### PR TITLE
fix issue with single quote arguments for String.format in EAP7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,13 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit5.version}</version>
             <scope>test</scope>

--- a/src/main/java/biz/paluch/logging/gelf/jul/JulLogEvent.java
+++ b/src/main/java/biz/paluch/logging/gelf/jul/JulLogEvent.java
@@ -68,14 +68,15 @@ public class JulLogEvent implements LogEvent {
             String originalMessage = message;
 
             // by default, using {0}, {1}, etc. -> MessageFormat
-
-            try {
-                message = MessageFormat.format(message, parameters);
-            } catch (IllegalArgumentException e) {
-                // leaving message as it is to avoid compatibility problems
-                message = record.getMessage();
-            } catch (NullPointerException e) {
-                // ignore
+            if(message.contains("{")) {
+                try {
+                    message = MessageFormat.format(message, parameters);
+                } catch (IllegalArgumentException e) {
+                    // leaving message as it is to avoid compatibility problems
+                    message = record.getMessage();
+                } catch (NullPointerException e) {
+                    // ignore
+                }
             }
 
             if (message.equals(originalMessage)) {

--- a/src/test/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandlerTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/jboss7/JBoss7GelfLogHandlerTests.java
@@ -1,22 +1,21 @@
 package biz.paluch.logging.gelf.jboss7;
 
-import static biz.paluch.logging.gelf.jboss7.JBoss7LogTestUtil.getJBoss7GelfLogHandler;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
-
+import biz.paluch.logging.gelf.GelfTestSender;
+import biz.paluch.logging.gelf.LogMessageField;
+import biz.paluch.logging.gelf.intern.GelfMessage;
 import org.jboss.logmanager.MDC;
 import org.jboss.logmanager.NDC;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import biz.paluch.logging.gelf.GelfTestSender;
-import biz.paluch.logging.gelf.LogMessageField;
-import biz.paluch.logging.gelf.intern.GelfMessage;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import static biz.paluch.logging.gelf.jboss7.JBoss7LogTestUtil.getJBoss7GelfLogHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mark Paluch
@@ -135,47 +134,6 @@ class JBoss7GelfLogHandlerTests {
     }
 
     @Test
-    void testSimpleWithMsgFormatSubstitution() throws Exception {
-
-        JBoss7GelfLogHandler handler = getJBoss7GelfLogHandler();
-
-        Logger logger = Logger.getLogger(getClass().getName());
-        logger.addHandler(handler);
-
-        String logMessage = "foo bar test log message {0}";
-        String expectedMessage = "foo bar test log message aaa";
-        logger.log(Level.INFO, logMessage, new String[] { "aaa" });
-        assertThat(GelfTestSender.getMessages()).hasSize(1);
-
-        GelfMessage gelfMessage = GelfTestSender.getMessages().get(0);
-
-        assertThat(gelfMessage.getFullMessage()).isEqualTo(expectedMessage);
-        assertThat(gelfMessage.getShortMessage()).isEqualTo(expectedMessage);
-        assertThat(gelfMessage.getLevel()).isEqualTo("6");
-        assertThat(gelfMessage.getMaximumMessageSize()).isEqualTo(8192);
-    }
-
-    @Test
-    void testSimpleWithStringFormatSubstitution() throws Exception {
-
-        JBoss7GelfLogHandler handler = getJBoss7GelfLogHandler();
-
-        Logger logger = Logger.getLogger(getClass().getName());
-        logger.addHandler(handler);
-
-        String logMessage = "foo bar test log message %s";
-        String expectedMessage = "foo bar test log message aaa";
-
-        logger.log(Level.INFO, logMessage, new String[] { "aaa" });
-        assertThat(GelfTestSender.getMessages()).hasSize(1);
-
-        GelfMessage gelfMessage = GelfTestSender.getMessages().get(0);
-
-        assertThat(gelfMessage.getFullMessage()).isEqualTo(expectedMessage);
-        assertThat(gelfMessage.getShortMessage()).isEqualTo(expectedMessage);
-    }
-
-    @Test
     void testFields() throws Exception {
 
         JBoss7GelfLogHandler handler = getJBoss7GelfLogHandler();
@@ -200,6 +158,7 @@ class JBoss7GelfLogHandlerTests {
     void testWrongConfig() throws Exception {
 
         assertThrows(IllegalArgumentException.class, new Executable() {
+
             @Override
             public void execute() throws Throwable {
                 JBoss7GelfLogHandler handler = new JBoss7GelfLogHandler();

--- a/src/test/java/biz/paluch/logging/gelf/jboss7/Jboss7GelfLogHandlerMessageFormatTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/jboss7/Jboss7GelfLogHandlerMessageFormatTests.java
@@ -1,0 +1,46 @@
+package biz.paluch.logging.gelf.jboss7;
+
+import biz.paluch.logging.gelf.GelfTestSender;
+import biz.paluch.logging.gelf.intern.GelfMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import static biz.paluch.logging.gelf.jboss7.JBoss7LogTestUtil.getJBoss7GelfLogHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Jboss7GelfLogHandlerMessageFormatTests {
+
+    @BeforeEach
+    public void beforeEach() {
+        GelfTestSender.getMessages().clear();
+        LogManager.getLogManager().reset();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+                       "foo bar %s,     foo bar aaa",
+                       "foo bar '%s',   foo bar 'aaa'",
+                       "foo bar ''%s'', foo bar ''aaa''",
+                       "foo bar {0},    foo bar aaa",
+                       "%sdfsdfk#! {0}, %sdfsdfk#! aaa"
+               })
+    public void testMessageFormatting(String logMessage, String expectedMessage) {
+        JBoss7GelfLogHandler handler = getJBoss7GelfLogHandler();
+
+        Logger logger = Logger.getLogger(getClass().getName());
+        logger.addHandler(handler);
+
+        logger.log(Level.INFO, logMessage, new String[] { "aaa" });
+        assertThat(GelfTestSender.getMessages()).hasSize(1);
+
+        GelfMessage gelfMessage = GelfTestSender.getMessages().get(0);
+
+        assertThat(gelfMessage.getFullMessage()).isEqualTo(expectedMessage);
+        assertThat(gelfMessage.getShortMessage()).isEqualTo(expectedMessage);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/logstash-gelf/blob/master/.github/CONTRIBUTING.md).
- [x] You use the code formatters provided [here](https://github.com/mp911de/logstash-gelf/blob/master/as7formatter.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

Hey Mark, 

we are using logstash-gelf for Applications on JBoss EAP 7.

We noticed that some of the JBoss startup messages are not displayed properly when sending via logstash-gelf.
Example after formatting:
`WFLYEJB0473: JNDI bindings for session bean named %s in deployment unit %s are as follows:%s`
Message Format Template:
`JNDI bindings for session bean named '%s' in deployment unit '%s' are as follows:%s`

This message comes from Wildfly (see the following line in Wildfly: https://github.com/wildfly/wildfly/blob/cd1a5e2393052f3a91e77e581dfeee839d6f819d/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java#L3059 ).

The log message has single quotes which get removed by the MessageFormat call. Afterwards a subsequent String.format will not be applied (because the String was changed and is now missing the single quotes).

One easy fix for that is to check whether there is a MessageFormat identifier ("{") inside the message and skip MessageFormat if that's not the case. 
Although this won't solve all cases it should be good enough to fix the Startup Messages and not break something else.