### PR TITLE
Add constant write backoff in GelfTCPSender for cases when a sender c…

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/BackOff.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/BackOff.java
@@ -1,0 +1,5 @@
+package biz.paluch.logging.gelf.intern.sender;
+
+public interface BackOff {
+    BackOffExecution start();
+}

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/BackOffExecution.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/BackOffExecution.java
@@ -1,0 +1,8 @@
+package biz.paluch.logging.gelf.intern.sender;
+
+public interface BackOffExecution {
+    /**
+     * @return time in ms to wait before a next attempt
+     */
+    int nextBackOff();
+}

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/ConstantBackOff.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/ConstantBackOff.java
@@ -1,0 +1,19 @@
+package biz.paluch.logging.gelf.intern.sender;
+
+public class ConstantBackOff implements BackOff {
+    private final int backoffTimeMs;
+
+    public ConstantBackOff(int backoffTimeMs) {
+        this.backoffTimeMs = backoffTimeMs;
+    }
+
+    @Override
+    public BackOffExecution start() {
+        return new BackOffExecution() {
+            @Override
+            public int nextBackOff() {
+                return backoffTimeMs;
+            }
+        };
+    }
+}

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/DefaultGelfSenderProvider.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/DefaultGelfSenderProvider.java
@@ -53,7 +53,7 @@ public class DefaultGelfSenderProvider implements GelfSenderProvider {
             String tcpGraylogHost = QueryStringParser.getHost(uri);
 
             return new GelfTCPSender(tcpGraylogHost, port, connectionTimeMs, readTimeMs, deliveryAttempts, keepAlive,
-                    writeBackoffTimeMs, writeBackoffThreshold, maxWriteBackoffTimeMs,
+                    new ConstantBackOff(writeBackoffTimeMs), writeBackoffThreshold, maxWriteBackoffTimeMs,
                     configuration.getErrorReporter());
         }
     };

--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/DefaultGelfSenderProvider.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/DefaultGelfSenderProvider.java
@@ -46,9 +46,14 @@ public class DefaultGelfSenderProvider implements GelfSenderProvider {
             int deliveryAttempts = QueryStringParser.getInt(params, GelfTCPSender.RETRIES, 1);
             boolean keepAlive = QueryStringParser.getString(params, GelfTCPSender.KEEPALIVE, false);
 
+            int writeBackoffTimeMs =  (int) QueryStringParser.getTimeAsMs(params, GelfTCPSender.WRITE_BACKOFF_TIME, 50);
+            int writeBackoffThreshold = QueryStringParser.getInt(params, GelfTCPSender.WRITE_BACKOFF_THRESHOLD, 10);
+            int maxWriteBackoffTimeMs = (int) QueryStringParser.getTimeAsMs(params, GelfTCPSender.MAX_WRITE_BACKOFF_TIME, connectionTimeMs);
+
             String tcpGraylogHost = QueryStringParser.getHost(uri);
 
             return new GelfTCPSender(tcpGraylogHost, port, connectionTimeMs, readTimeMs, deliveryAttempts, keepAlive,
+                    writeBackoffTimeMs, writeBackoffThreshold, maxWriteBackoffTimeMs,
                     configuration.getErrorReporter());
         }
     };

--- a/src/site/markdown/tcp.md
+++ b/src/site/markdown/tcp.md
@@ -17,7 +17,10 @@ The TCP transport for logstash-gelf allows to configure TCP-specific options. Op
 * `readTimeout` Socket Read-Timeout (SO_TIMEOUT). The unit can be specified as suffix (see below). A timeout of zero is interpreted as an infinite timeout. Defaults to `2s`. 
 * `connectionTimeout` Socket Connection-Timeout (SO_TIMEOUT). The unit can be specified as suffix (see below). A timeout of zero is interpreted as an infinite timeout. Defaults to `2s`.
 * `deliveryAttempts` Number of Delivery-Attempts. Will retry to deliver the message and reconnect if necessary. A number of zero is interpreted as an infinite attempts. Defaults to `1`.   
-* `keepAlive` Enable TCP keepAlive. Defaults to `false`.   
+* `keepAlive` Enable TCP keepAlive. Defaults to `false`. 
+* `writeBackoffTime` Delay between subsequent attempts to write to a socket when a backoff is activated. Backoff is activated if a socket sender buffer is full and several attempts to write to the socket are unsuccessful due to it. The unit can be specified as suffix (see below). Defaults to `50ms`. 
+* `writeBackoffThreshold` Attempts to write to a socket before a backoff will be activated. Defaults to `10`. 
+* `maxWriteBackoffTime` Maximum time spent for awaiting during a backoff for a single message send operation. The unit can be specified as suffix (see below). Default equals to `connectionTimeout`. 
 
 ## SSL
 


### PR DESCRIPTION
…annot write any bytes to the socket channel several times. Limit the time to stay in such mode.

fixes #248