### PR TITLE
Better field type detection, fixes #250

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/intern/ValueDiscovery.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/ValueDiscovery.java
@@ -1,5 +1,7 @@
 package biz.paluch.logging.gelf.intern;
 
+import java.util.regex.Pattern;
+
 /**
  * Data type discovery for {@link String} value types. Discovers an indicator whether a type is a {@link Result#LONG}, a
  * {@link Result#DOUBLE} or {@link Result#STRING} type.
@@ -7,89 +9,73 @@ package biz.paluch.logging.gelf.intern;
  * @author <a href="mailto:mpaluch@paluch.biz">Mark Paluch</a>
  */
 class ValueDiscovery {
+    private static final Pattern longPattern = Pattern.compile("^(0x[0-9a-fA-F]+)|[+\\-]?0|[+\\-]?[1-9][0-9]{0,18}$");
+    private static final Pattern doublePattern = Pattern.compile("^[+\\-]?(([0-9]*\\.[0-9]+([eE][+-]?[0-9]+)?)|([1-9][0-9]{0,18}([eE][+-]?[0-9]+)?)|(0x[0-9a-fA-F]+\\.[0-9a-fA-F]+[pP][+\\-]?[0-9]+))$");
 
     static Result discover(String value) {
-
         long len = value.length();
 
         if (len == 0 || len > 32) {
             return Result.STRING;
         }
 
-        int points = -1;
-
         char firstChar = value.charAt(0);
         if (firstChar < '0' || firstChar > '9') { // Possible leading "+" or "-"
-
-            if (firstChar == 'N' && value.contains("NaN")) {
+            if (firstChar == 'N' && len == 3 && value.equals("NaN")) {
+                return Result.DOUBLE;
+            } else if (firstChar == 'I' && len == 8 && value.equals("Infinity")) {
+                return Result.DOUBLE;
+            } else if (firstChar == '+' && len == 9 && value.equals("+Infinity")) {
+                return Result.DOUBLE;
+            } else if (firstChar == '-' && len == 9 && value.equals("-Infinity")) {
                 return Result.DOUBLE;
             }
-
-            if (firstChar == 'I' && value.contains("Infinity")) {
-                return Result.DOUBLE;
-            }
-
             if (firstChar != '-' && firstChar != '+') {
                 return Result.STRING;
             }
         }
 
-        Result discoveryResult = Result.LONG;
+        boolean numbersOnly = true;
 
-        for (int i = 1; i < len; i++) {
+        for (int pos = 0; pos < Math.min(len, 20); pos++) {
 
-            char c = value.charAt(i);
+            char c = value.charAt(pos);
 
-            if (c >= '0' && c <= '9') {
+            numbersOnly &= (c >= '0' && c <= '9');
+            if (numbersOnly) {
                 continue;
             }
 
-            switch (c) {
-
-                case '.':
-
-                    if (points != -1) {
-                        return Result.STRING;
-                    }
-
-                    points = i;
-                    discoveryResult = Result.DOUBLE;
-                    break;
-
-                case '-':
-                case '+':
-                    discoveryResult = Result.DOUBLE;
-                    break;
-                case 'a':
-                case 'b':
-                case 'c':
-                case 'd':
-                case 'e':
-                case 'f':
-                case 'A':
-                case 'B':
-                case 'C':
-                case 'D':
-                case 'E':
-                case 'F':
-                case 'x':
-                case 'X':
-                case 'P':
-                case 'p':
-                    discoveryResult = Result.DOUBLE;
-                    break;
-                default:
-                    return Result.STRING;
-
+            if ((c != '+') &&
+                (c != '-') &&
+                (c < '0' || c > '9') &&
+                (c < 'a' || c > 'f') && (c < 'A' || c > 'F') &&
+                (c != '.') &&
+                (c != 'x' && c != 'X') &&
+                (c != 'p' && c != 'P')) {
+                return Result.STRING;
             }
         }
 
-        return discoveryResult;
+        if (numbersOnly) {
+            if (len == 1) {
+                return Result.LONG;
+            } else if (len <= 19 && firstChar != '0') {
+                return Result.LONG;
+            } else {
+                return Result.STRING;
+            }
+        } else if (longPattern.matcher(value).matches()) {
+            return Result.LONG;
+        } else if (doublePattern.matcher(value).matches()) {
+            return Result.DOUBLE;
+        }
+        return Result.STRING;
     }
 
     enum Result {
 
-        STRING, LONG, DOUBLE;
+        STRING, LONG, DOUBLE
 
     }
 }

--- a/src/test/java/biz/paluch/logging/gelf/intern/ValueDiscoveryUnitTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/ValueDiscoveryUnitTests.java
@@ -70,7 +70,7 @@ class ValueDiscoveryUnitTests {
     void doubleWithChars() {
 
         assertThat(ValueDiscovery.discover("2e5")).isEqualTo(Result.DOUBLE);
-        assertThat(ValueDiscovery.discover("2e5.1")).isEqualTo(Result.DOUBLE);
+        assertThat(ValueDiscovery.discover("2e5.1")).isEqualTo(Result.STRING);
         assertThat(ValueDiscovery.discover("1.2.3")).isEqualTo(Result.STRING);
         assertThat(ValueDiscovery.discover("A")).isEqualTo(Result.STRING);
         assertThat(ValueDiscovery.discover("9.156013e-002")).isEqualTo(Result.DOUBLE);
@@ -80,8 +80,56 @@ class ValueDiscoveryUnitTests {
 
     @Test
     void shouldDiscoverStringExceedingLength() {
-
-        assertThat(ValueDiscovery.discover("11111111111111111111111111111111")).isEqualTo(Result.LONG);
+        assertThat(ValueDiscovery.discover("1111111111111111111")).isEqualTo(Result.LONG);
+        assertThat(ValueDiscovery.discover("11111111111111111111")).isEqualTo(Result.STRING);
         assertThat(ValueDiscovery.discover("111111111111111111111111111111111")).isEqualTo(Result.STRING);
     }
+
+    @Test
+    void testString() {
+        assertThat(ValueDiscovery.discover("deadbeef")).isEqualTo(ValueDiscovery.Result.STRING);
+    }
+
+    @Test
+    void testHexString() {
+        assertThat(ValueDiscovery.discover("0xdeadbeef")).isEqualTo(Result.LONG);
+    }
+
+    @Test
+    void testStringWithLeadingZeroAndHex() {
+        assertThat(ValueDiscovery.discover("0deadbeef")).isEqualTo(ValueDiscovery.Result.STRING);
+        assertThat(ValueDiscovery.discover("0123")).isEqualTo(ValueDiscovery.Result.STRING);
+    }
+
+    @Test
+    void testStringZeroAndP() {
+        assertThat(ValueDiscovery.discover("0p")).isEqualTo(ValueDiscovery.Result.STRING);
+    }
+
+    @Test
+    void testStringZeroAndX() {
+        assertThat(ValueDiscovery.discover("0x")).isEqualTo(ValueDiscovery.Result.STRING);
+    }
+
+    @Test
+    void testStringZeroXP() {
+        assertThat(ValueDiscovery.discover("0xp")).isEqualTo(ValueDiscovery.Result.STRING);
+    }
+
+    @Test
+    void testInfinity() {
+        assertThat(ValueDiscovery.discover("Infinity")).isEqualTo(ValueDiscovery.Result.DOUBLE);
+        assertThat(ValueDiscovery.discover("+Infinity")).isEqualTo(ValueDiscovery.Result.DOUBLE);
+        assertThat(ValueDiscovery.discover("-Infinity")).isEqualTo(ValueDiscovery.Result.DOUBLE);
+        assertThat(ValueDiscovery.discover("Infinity1")).isEqualTo(ValueDiscovery.Result.STRING);
+    }
+
+    @Test
+    void testNaN() {
+        assertThat(ValueDiscovery.discover("NaN")).isEqualTo(ValueDiscovery.Result.DOUBLE);
+        assertThat(ValueDiscovery.discover("+NaN")).isEqualTo(ValueDiscovery.Result.STRING);
+        assertThat(ValueDiscovery.discover("-NaN")).isEqualTo(ValueDiscovery.Result.STRING);
+        assertThat(ValueDiscovery.discover("NaN1")).isEqualTo(ValueDiscovery.Result.STRING);
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/mp911de/logstash-gelf/blob/master/.github/CONTRIBUTING.md).
- [ ] You use the code formatters provided [here](https://github.com/mp911de/logstash-gelf/blob/master/as7formatter.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

Performance is slightly worse, especially for Doubles.

Current code:
```
GelfMessageBenchmark.discoverDoubleField                     avgt    5     34,866 ±   4,471  ns/op
GelfMessageBenchmark.discoverLongField                       avgt    5     15,418 ±   2,406  ns/op
GelfMessageBenchmark.discoverStringField                     avgt    5      5,405 ±   1,440  ns/op
```

New code:
```
GelfMessageBenchmark.discoverDoubleField  avgt    5  235,740 ± 5,143  ns/op
GelfMessageBenchmark.discoverLongField    avgt    5   26,484 ± 1,803  ns/op
GelfMessageBenchmark.discoverStringField  avgt    5    5,242 ± 0,254  ns/op
```
