### PR TITLE
Hide sensitive info from error message

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSender.java
@@ -76,7 +76,12 @@ public class GelfHTTPSender implements GelfSender {
             errorReporter.reportError("Server responded with unexpected status code: " + responseCode, null);
 
         } catch (IOException e) {
-            errorReporter.reportError("Cannot send data to " + url, e);
+            String cleanUrl = url.toString();
+            String userInfo = url.getUserInfo();
+            if (userInfo != null) {
+                cleanUrl = cleanUrl.replace(userInfo + "@", "");
+            }
+            errorReporter.reportError("Cannot send data to " + cleanUrl, e);
         } finally {
             // disconnecting HttpURLConnection here to avoid underlying premature underlying Socket being closed.
             if (connection != null) {

--- a/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSenderIntegrationTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/intern/sender/GelfHTTPSenderIntegrationTests.java
@@ -144,4 +144,19 @@ class GelfHTTPSenderIntegrationTests {
         verify(errorReporter, times(1)).reportError(anyString(), ArgumentMatchers.<Exception> isNull());
     }
 
+    @Test
+    void sendMessageFailureUserInfoTest() throws IOException {
+
+        server.setReturnStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+
+        String uri = "http://foo:(.*bar)@127.0.0.1:19394"; // unreachable host, and a regex
+        GelfHTTPSender sender = new GelfHTTPSender(new URL(uri), 1000, 1000, errorReporter);
+
+        boolean success = sender.sendMessage(GELF_MESSAGE);
+
+        assertThat(success).isFalse();
+        verify(errorReporter, times(1)).reportError(
+                ArgumentMatchers.eq("Cannot send data to http://127.0.0.1:19394"), ArgumentMatchers.<Exception> isNotNull());
+    }
+
 }


### PR DESCRIPTION
Amending #254. The error message should not include userInfo which can contain sensitive information.