### PR TITLE
Add fullMessageTraceOnly property

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/PropertyProvider.java
+++ b/src/main/java/biz/paluch/logging/gelf/PropertyProvider.java
@@ -37,6 +37,7 @@ public interface PropertyProvider {
     String PROPERTY_ADDITIONAL_FIELD_TYPES = "additionalFieldTypes";
     String PROPERTY_DYNAMIC_MDC_FIELD_TYPES = "dynamicMdcFieldTypes";
     String PROPERTY_TIMESTAMP_PATTERN = "timestampPattern";
+    String PROPERTY_FULL_MESSAGE_TRACE_ONLY = "fullMessageTraceOnly";
 
     String PROPERTY_FILTER = "filter";
     String PROPERTY_LEVEL = "level";

--- a/src/main/java/biz/paluch/logging/gelf/jul/GelfFormatter.java
+++ b/src/main/java/biz/paluch/logging/gelf/jul/GelfFormatter.java
@@ -42,6 +42,7 @@ import biz.paluch.logging.gelf.intern.GelfMessage;
  * <li>extractStackTrace (Optional): Post Stack-Trace to StackTrace field (true/false/throwable reference [0 = throwable, 1 =
  * throwable.cause, -1 = root cause]), default false</li>
  * <li>filterStackTrace (Optional): Perform Stack-Trace filtering (true/false), default false</li>
+ * <li>fullMessageTraceOnly (Optional): Use GELF's full_message field exclusively for stack traces, default false</li>
  * <li>includeLocation (Optional): Include source code location, default true</li>
  * <li>includeLogMessageParameters (Optional): Include message parameters from the log event (see
  * {@link LogRecord#getParameters()}, default true</li>
@@ -110,6 +111,11 @@ public class GelfFormatter extends Formatter {
         val = manager.getProperty(cname + ".filterStackTrace");
         if (val != null) {
             setFilterStackTrace(Boolean.valueOf(val));
+        }
+
+        val = manager.getProperty(cname + ".fullMessageTraceOnly");
+        if (val != null) {
+            setFullMessageTraceOnly(Boolean.valueOf(val));
         }
 
         val = manager.getProperty(cname + ".includeLogMessageParameters");
@@ -225,6 +231,14 @@ public class GelfFormatter extends Formatter {
 
     public void setFilterStackTrace(boolean filterStackTrace) {
         gelfMessageAssembler.setFilterStackTrace(filterStackTrace);
+    }
+
+    public boolean isFullMessageTraceOnly() {
+        return gelfMessageAssembler.isFullMessageTraceOnly();
+    }
+
+    public void setFullMessageTraceOnly(boolean fullMessageTraceOnly) {
+        gelfMessageAssembler.setFullMessageTraceOnly(fullMessageTraceOnly);
     }
 
     public boolean isIncludeLogMessageParameters() {

--- a/src/main/java/biz/paluch/logging/gelf/jul/GelfLogHandler.java
+++ b/src/main/java/biz/paluch/logging/gelf/jul/GelfLogHandler.java
@@ -284,4 +284,12 @@ public class GelfLogHandler extends Handler implements ErrorReporter {
     public void setVersion(String version) {
         gelfMessageAssembler.setVersion(version);
     }
+
+    public boolean isFullMessageTraceOnly() {
+        return gelfMessageAssembler.isFullMessageTraceOnly();
+    }
+
+    public void setFullMessageTraceOnly(boolean fullMessageTraceOnly) {
+        gelfMessageAssembler.setFullMessageTraceOnly(fullMessageTraceOnly);
+    }
 }

--- a/src/main/java/biz/paluch/logging/gelf/logback/GelfLogbackAppender.java
+++ b/src/main/java/biz/paluch/logging/gelf/logback/GelfLogbackAppender.java
@@ -266,4 +266,12 @@ public class GelfLogbackAppender extends AppenderBase<ILoggingEvent> implements 
         gelfMessageAssembler.setVersion(version);
     }
 
+    public boolean isFullMessageTraceOnly() {
+        return gelfMessageAssembler.isFullMessageTraceOnly();
+    }
+
+    public void setFullMessageTraceOnly(boolean fullMessageTraceOnly) {
+        gelfMessageAssembler.setFullMessageTraceOnly(fullMessageTraceOnly);
+    }
+
 }

--- a/src/test/java/biz/paluch/logging/gelf/logback/GelfLogbackAppenderTraceOnlyTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/logback/GelfLogbackAppenderTraceOnlyTests.java
@@ -1,0 +1,81 @@
+package biz.paluch.logging.gelf.logback;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import biz.paluch.logging.gelf.GelfTestSender;
+import biz.paluch.logging.gelf.LogMessageField;
+import biz.paluch.logging.gelf.MdcGelfMessageAssembler;
+import biz.paluch.logging.gelf.intern.GelfMessage;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+
+class GelfLogbackAppenderTraceOnlyTests {
+
+    private static final String LOG_MESSAGE = "foo bar test log message";
+    private static final String EXPECTED_LOG_MESSAGE = LOG_MESSAGE;
+
+    LoggerContext lc = null;
+
+    @BeforeEach
+    void before() throws Exception {
+        lc = new LoggerContext();
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(lc);
+
+        URL xmlConfigFile = getClass().getResource("/logback/logback-gelf-with-traceonly.xml");
+
+        configurator.doConfigure(xmlConfigFile);
+
+        GelfTestSender.getMessages().clear();
+
+        MDC.remove("mdcField1");
+    }
+
+    @Test
+    void testSimpleInfo() throws Exception {
+
+        Logger logger = lc.getLogger(getClass());
+
+        logger.info(LOG_MESSAGE);
+        assertThat(GelfTestSender.getMessages()).hasSize(1);
+
+        GelfMessage gelfMessage = GelfTestSender.getMessages().get(0);
+
+        assertThat(gelfMessage.getFullMessage()).isNull();
+        assertThat(gelfMessage.getShortMessage()).isEqualTo(EXPECTED_LOG_MESSAGE);
+        assertThat(gelfMessage.getVersion()).isEqualTo(GelfMessage.GELF_VERSION_1_1);
+        assertThat(gelfMessage.getField("MyTime")).isNotNull();
+        assertThat(gelfMessage.getLevel()).isEqualTo("6");
+        assertThat(gelfMessage.getMaximumMessageSize()).isEqualTo(8192);
+
+    }
+
+    @Test
+    void testException() throws Exception {
+
+        Logger logger = lc.getLogger(getClass());
+
+        logger.info(LOG_MESSAGE, new Exception("this is an exception"));
+        assertThat(GelfTestSender.getMessages()).hasSize(1);
+
+        GelfMessage gelfMessage = GelfTestSender.getMessages().get(0);
+
+        assertThat(gelfMessage.getShortMessage()).isEqualTo(EXPECTED_LOG_MESSAGE);
+        assertThat(gelfMessage.getFullMessage()).contains("this is an exception");
+        assertThat(gelfMessage.getField(LogMessageField.NamedLogField.SourceClassName.getFieldName()))
+                .isEqualTo(GelfLogbackAppenderTraceOnlyTests.class.getName());
+        assertThat(gelfMessage.getField(LogMessageField.NamedLogField.SourceMethodName.getFieldName()))
+                .isEqualTo("testException");
+
+        assertThat(gelfMessage.getField(MdcGelfMessageAssembler.FIELD_STACK_TRACE)).isNull();
+
+    }
+
+}

--- a/src/test/java/biz/paluch/logging/gelf/logback/GelfLogbackAppenderUnitTests.java
+++ b/src/test/java/biz/paluch/logging/gelf/logback/GelfLogbackAppenderUnitTests.java
@@ -34,6 +34,7 @@ class GelfLogbackAppenderUnitTests {
         sut.setIncludeFullMdc(true);
         sut.setMdcFields("");
         sut.setMdcProfiling(true);
+        sut.setFullMessageTraceOnly(true);
 
         assertThat(sut.getFacility()).isEqualTo(FACILITY);
         assertThat(sut.getGraylogHost()).isEqualTo(HOST);
@@ -48,6 +49,7 @@ class GelfLogbackAppenderUnitTests {
         assertThat(sut.isFilterStackTrace()).isTrue();
         assertThat(sut.isIncludeFullMdc()).isTrue();
         assertThat(sut.isMdcProfiling()).isTrue();
+        assertThat(sut.isFullMessageTraceOnly()).isTrue();
     }
 
     @Test

--- a/src/test/resources/logback/logback-gelf-with-traceonly.xml
+++ b/src/test/resources/logback/logback-gelf-with-traceonly.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration debug="true">
+    <contextName>test</contextName>
+    <jmxConfigurator/>
+
+    <appender name="GELF" class="biz.paluch.logging.gelf.logback.GelfLogbackAppender">
+        <graylogHost>test:localhost</graylogHost>
+        <graylogPort>12201</graylogPort>
+        <version>1.1</version>
+        <facility>logstash-gelf</facility>
+        <extractStackTrace>true</extractStackTrace>
+        <filterStackTrace>false</filterStackTrace>
+        <fullMessageTraceOnly>true</fullMessageTraceOnly>
+        <mdcProfiling>true</mdcProfiling>
+        <timestampPattern>yyyy-MM-dd HH:mm:ss,SSS</timestampPattern>
+        <maximumMessageSize>8192</maximumMessageSize>
+        <additionalFields>fieldName1=fieldValue1,fieldName2=fieldValue2</additionalFields>
+        <mdcFields>mdcField1,mdcField2</mdcFields>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="GELF" />
+    </root>
+</configuration>


### PR DESCRIPTION
**This PR is incomplete (missing tests; not all backends updated). Looking for feedback before continuing.**

When enabled, fullMessageTraceOnly causes logstash-gelf to use GELF's full_message field exclusively for stack traces. Otherwise, default behavior is to duplicate the log message in both short_message and full_message fields, using full_message to overcome truncation of short_message max length.

In many cases, short_message and full_message are identical, so the default behavior is inefficient. Furthermore, some GELF servers treat full_message specially (e.g. Seq expects traces in full_message).