### PR TITLE
Add YAML example for Log4j2

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,9 @@ appender.gelf:
     includeFullMdc: true
     mdcProfiling: true
     maximumMessageSize: 32768
-    dynamicMdcFields.type: DynamicMdcFields
-    dynamicMdcFields.regex: "mdc.*,(mdc|MDC)fields"
+    dynamicMdcFields:
+        type: DynamicMdcFields
+        regex: "mdc.*,(mdc|MDC)fields"
 
     fieldName2:
         type: Field
@@ -279,6 +280,7 @@ appender.gelf:
         type: Field
         name: className
         pattern: "%C"
+        
     lineNumber:
         type: Field
         name: lineNumber

--- a/README.md
+++ b/README.md
@@ -254,28 +254,35 @@ host{["fqdn"<br/>"simple"<br/>"address"]} | Outputs either the FQDN hostname, th
 
 **YAML**
 ```yaml
-    rootLogger.level = INFO
-    rootLogger.appenderRef.gelf.ref = GelfAppender
+rootLogger:
+    level: INFO
+    appenderRef.gelf.ref: GelfAppender
 
-    appender.gelf.type = Gelf
-    appender.gelf.name = GelfAppender
-    appender.gelf.host = udp:localhost
-    appender.gelf.port = 12201
-    appender.gelf.version = 1.0
-    appender.gelf.includeFullMdc = true
-    appender.gelf.mdcProfiling = true
-    appender.gelf.maximumMessageSize = 32768
-    appender.gelf.dynamicMdcFields.type=DynamicMdcFields
-    appender.gelf.dynamicMdcFields.regex=mdc.*,(mdc|MDC)fields
-    appender.gelf.fieldName2.type = Field
-    appender.gelf.fieldName2.name = fieldName2
-    appender.gelf.fieldName2.literal = fieldName2 # This is a static field
-    appender.gelf.className.type = Field
-    appender.gelf.className.name = className
-    appender.gelf.className.pattern = %C
-    appender.gelf.lineNumber.type = Field
-    appender.gelf.lineNumber.name = lineNumber
-    appender.gelf.lineNumber.pattern = %line
+appender.gelf:
+    type: Gelf
+    name: GelfAppender
+    host: udp:localhost
+    port: 12201
+    version: 1.0
+    includeFullMdc: true
+    mdcProfiling: true
+    maximumMessageSize: 32768
+    dynamicMdcFields.type: DynamicMdcFields
+    dynamicMdcFields.regex: "mdc.*,(mdc|MDC)fields"
+
+    fieldName2:
+        type: Field
+        name: fieldName2
+        literal: fieldName2 # This is a static field
+
+    className:
+        type: Field
+        name: className
+        pattern: "%C"
+    lineNumber:
+        type: Field
+        name: lineNumber
+        pattern: "%line"
 ```
 
 <a name="jbossas7"/>

--- a/README.md
+++ b/README.md
@@ -252,6 +252,32 @@ host{["fqdn"<br/>"simple"<br/>"address"]} | Outputs either the FQDN hostname, th
 </Configuration>    
 ```    
 
+**YAML**
+```yaml
+    rootLogger.level = INFO
+    rootLogger.appenderRef.gelf.ref = GelfAppender
+
+    appender.gelf.type = Gelf
+    appender.gelf.name = GelfAppender
+    appender.gelf.host = udp:localhost
+    appender.gelf.port = 12201
+    appender.gelf.version = 1.0
+    appender.gelf.includeFullMdc = true
+    appender.gelf.mdcProfiling = true
+    appender.gelf.maximumMessageSize = 32768
+    appender.gelf.dynamicMdcFields.type=DynamicMdcFields
+    appender.gelf.dynamicMdcFields.regex=mdc.*,(mdc|MDC)fields
+    appender.gelf.fieldName2.type = Field
+    appender.gelf.fieldName2.name = fieldName2
+    appender.gelf.fieldName2.literal = fieldName2 # This is a static field
+    appender.gelf.className.type = Field
+    appender.gelf.className.name = className
+    appender.gelf.className.pattern = %C
+    appender.gelf.lineNumber.type = Field
+    appender.gelf.lineNumber.name = lineNumber
+    appender.gelf.lineNumber.pattern = %line
+```
+
 <a name="jbossas7"/>
 
 JBoss AS7 configuration

--- a/src/site/markdown/examples/log4j-2.x.md
+++ b/src/site/markdown/examples/log4j-2.x.md
@@ -101,3 +101,27 @@ XML:
         </Loggers>
     </Configuration>
       
+YAML:
+
+    rootLogger.level = INFO
+    rootLogger.appenderRef.gelf.ref = GelfAppender
+
+    appender.gelf.type = Gelf
+    appender.gelf.name = GelfAppender
+    appender.gelf.host = udp:localhost
+    appender.gelf.port = 12201
+    appender.gelf.version = 1.0
+    appender.gelf.includeFullMdc = true
+    appender.gelf.mdcProfiling = true
+    appender.gelf.maximumMessageSize = 32768
+    appender.gelf.dynamicMdcFields.type=DynamicMdcFields
+    appender.gelf.dynamicMdcFields.regex=mdc.*,(mdc|MDC)fields
+    appender.gelf.fieldName2.type = Field
+    appender.gelf.fieldName2.name = fieldName2
+    appender.gelf.fieldName2.literal = fieldName2 # This is a static field
+    appender.gelf.className.type = Field
+    appender.gelf.className.name = className
+    appender.gelf.className.pattern = %C
+    appender.gelf.lineNumber.type = Field
+    appender.gelf.lineNumber.name = lineNumber
+    appender.gelf.lineNumber.pattern = %line

--- a/src/site/markdown/examples/log4j-2.x.md
+++ b/src/site/markdown/examples/log4j-2.x.md
@@ -102,26 +102,32 @@ XML:
     </Configuration>
       
 YAML:
+    rootLogger:
+        level: INFO
+        appenderRef.gelf.ref: GelfAppender
 
-    rootLogger.level = INFO
-    rootLogger.appenderRef.gelf.ref = GelfAppender
+    appender.gelf:
+        type: Gelf
+        name: GelfAppender
+        host: udp:localhost
+        port: 12201
+        version: 1.0
+        includeFullMdc: true
+        mdcProfiling: true
+        maximumMessageSize: 32768
+        dynamicMdcFields.type: DynamicMdcFields
+        dynamicMdcFields.regex: "mdc.*,(mdc|MDC)fields"
 
-    appender.gelf.type = Gelf
-    appender.gelf.name = GelfAppender
-    appender.gelf.host = udp:localhost
-    appender.gelf.port = 12201
-    appender.gelf.version = 1.0
-    appender.gelf.includeFullMdc = true
-    appender.gelf.mdcProfiling = true
-    appender.gelf.maximumMessageSize = 32768
-    appender.gelf.dynamicMdcFields.type=DynamicMdcFields
-    appender.gelf.dynamicMdcFields.regex=mdc.*,(mdc|MDC)fields
-    appender.gelf.fieldName2.type = Field
-    appender.gelf.fieldName2.name = fieldName2
-    appender.gelf.fieldName2.literal = fieldName2 # This is a static field
-    appender.gelf.className.type = Field
-    appender.gelf.className.name = className
-    appender.gelf.className.pattern = %C
-    appender.gelf.lineNumber.type = Field
-    appender.gelf.lineNumber.name = lineNumber
-    appender.gelf.lineNumber.pattern = %line
+        fieldName2:
+            type: Field
+            name: fieldName2
+            literal: fieldName2 # This is a static field
+
+        className:
+            type: Field
+            name: className
+            pattern: "%C"
+        lineNumber:
+            type: Field
+            name: lineNumber
+            pattern: "%line"

--- a/src/site/markdown/examples/log4j-2.x.md
+++ b/src/site/markdown/examples/log4j-2.x.md
@@ -115,8 +115,9 @@ YAML:
         includeFullMdc: true
         mdcProfiling: true
         maximumMessageSize: 32768
-        dynamicMdcFields.type: DynamicMdcFields
-        dynamicMdcFields.regex: "mdc.*,(mdc|MDC)fields"
+        dynamicMdcFields:
+            type: DynamicMdcFields
+            regex: "mdc.*,(mdc|MDC)fields"
 
         fieldName2:
             type: Field
@@ -127,6 +128,7 @@ YAML:
             type: Field
             name: className
             pattern: "%C"
+            
         lineNumber:
             type: Field
             name: lineNumber


### PR DESCRIPTION
We had some troubles upgrading from Log4j to Log4j2 with the new syntax. Adding a yaml section to the documentation to make it easier for the next person.