### PR TITLE
Added close on the channel after a port failure

### DIFF
--- a/src/main/java/biz/paluch/logging/gelf/intern/sender/AbstractNioSender.java
+++ b/src/main/java/biz/paluch/logging/gelf/intern/sender/AbstractNioSender.java
@@ -78,6 +78,7 @@ public abstract class AbstractNioSender<T extends AbstractSelectableChannel & By
                 return myChannel.read(byteBuffer) >= 0;
             } catch (PortUnreachableException e) {
                 errorReporter.reportError("Port " + getHost() + ":" + getPort() + " not reachable", e);
+                Closer.close(channel());
             } catch (IOException e) {
                 errorReporter.reportError("Cannot verify whether channel to " + getHost() + ":" + getPort() + " is connected: "
                         + e.getMessage(), e);


### PR DESCRIPTION
During a kubernetes deployment graylog may change location if the original pod closes and a new one opens. The DNS assigned to it will be updated appropriately but the gelf will never try to reconnect.

After a lot of debugging using the latest logstash-gelf and 
```
openjdk 11.0.9.1 2020-11-04
OpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.20.04)
OpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.20.04, mixed mode, sharing)
```

It was identified that in the UDPSender.java and lines 54-58 there was a strange issue. The first `isConnected()` was correctly reporting false but the inner `isConnected()` under the `connect()` function was incorrectly reporting true. The strange part was that the line that was forcing `isConnected()` to return false was the `myChannel.read(byteBuffer)`  which was throwing an exception.

In order to resolve this, the channel will be closed as soon as the port is unreachable (as there is no need to keep it open with an unreachable port ). 

In order to test this ( as I couldn't simple test it with code. ) we did test it outside kubernetes for easier control. 
2 graylog installations were deployed on 2 separate machines ( A , B ) and a new hosts entry was inserted into the machine running the java app with the gelf. the hosts entry was pointing to one of the machines (in which graylog was running) and in the other graylog was off. After the first 3-4 logs produced and correctly published to graylog the hosts entry was changed to point to the B machine and closed the graylog of A / opened graylog of B. As a result the messages were never redirected to the new machine without this change. 