### PR TITLE
Fix invalid YAML example for Log4j2

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,21 +271,13 @@ appender.gelf:
     dynamicMdcFields:
         type: DynamicMdcFields
         regex: "mdc.*,(mdc|MDC)fields"
-
-    fieldName2:
-        type: Field
-        name: fieldName2
-        literal: fieldName2 # This is a static field
-
-    className:
-        type: Field
-        name: className
-        pattern: "%C"
-        
-    lineNumber:
-        type: Field
-        name: lineNumber
-        pattern: "%line"
+    field:
+        - name: fieldName2
+          literal: fieldName2 # This is a static field
+        - name: className
+          pattern: "%C"
+        - name: lineNumber
+          pattern: "%line"
 ```
 
 <a name="jbossas7"/>

--- a/src/site/markdown/examples/log4j-2.x.md
+++ b/src/site/markdown/examples/log4j-2.x.md
@@ -119,18 +119,10 @@ YAML:
         dynamicMdcFields:
             type: DynamicMdcFields
             regex: "mdc.*,(mdc|MDC)fields"
-
-        fieldName2:
-            type: Field
-            name: fieldName2
-            literal: fieldName2 # This is a static field
-
-        className:
-            type: Field
-            name: className
-            pattern: "%C"
-            
-        lineNumber:
-            type: Field
-            name: lineNumber
-            pattern: "%line"
+        field:
+            - name: fieldName2
+              literal: fieldName2 # This is a static field
+            - name: className
+              pattern: "%C"
+            - name: lineNumber
+              pattern: "%line"


### PR DESCRIPTION
The old version of YAML example for Log4j2 throws

- ERROR Unable to locate plugin type for fieldName2
- ERROR Unable to locate plugin type for className
- ERROR Unable to locate plugin type for lineNumber
- ERROR Unable to locate plugin for fieldName2
- ERROR Unable to locate plugin for className
- ERROR Unable to locate plugin for lineNumber

on startup.