### PR TITLE
Support for wildlfy 27

### DIFF
--- a/src/main/assembly/module.xml
+++ b/src/main/assembly/module.xml
@@ -8,7 +8,8 @@
     </resources>
 
     <dependencies>
-        <module name="org.apache.log4j" />
+        <module name="org.apache.log4j" optional="true"/>
+        <module name="org.apache.logging.log4j" optional="true"/>
         <module name="org.slf4j" />
         <module name="javax.api" />
         <module name="org.jboss.logmanager" />


### PR DESCRIPTION
Willdfly 27 switched from log4jv1 to log4jv2.

In practice the only change needed is to point `module.xml` to `org.apache.logging.log4j` instead of `org.apache.log4j`.

To make this change backwards compatible we point to both modules optionally. Validated manually on wildfly 25 (log4jv1) and 27 (log4jv2).
